### PR TITLE
Improve MDX file reading and update Next.js build scripts

### DIFF
--- a/.changeset/slick-sheep-brush.md
+++ b/.changeset/slick-sheep-brush.md
@@ -1,0 +1,8 @@
+---
+"@docubook/core": patch
+---
+
+Fix file reading logic in `readMdxFileBySlug` to try all candidate paths before failing:
+
+- Change catch block in the path loop from throwing error immediately to continuing to the next path, ensuring both `${slug}.mdx` and `slug/index.mdx` are attempted before throwing "Could not find mdx file".
+- This prevents premature failures when the file exists in the second path (e.g., `slug/index.mdx` for folder-based slugs).

--- a/.changeset/slick-sheep-brush.md
+++ b/.changeset/slick-sheep-brush.md
@@ -1,8 +1,0 @@
----
-"@docubook/core": patch
----
-
-Fix file reading logic in `readMdxFileBySlug` to try all candidate paths before failing:
-
-- Change catch block in the path loop from throwing error immediately to continuing to the next path, ensuring both `${slug}.mdx` and `slug/index.mdx` are attempted before throwing "Could not find mdx file".
-- This prevents premature failures when the file exists in the second path (e.g., `slug/index.mdx` for folder-based slugs).

--- a/apps/web/lib/markdown.ts
+++ b/apps/web/lib/markdown.ts
@@ -30,14 +30,21 @@ export type BaseMdxFrontmatter = {
 // `React.cache` deduplicates calls within a single server-render pass.
 // Keep request-level cache in app layer, while markdown pipeline lives in core.
 
+const fileMtimeCache = new Map<string, Date>();
+
 /**
  * Return the mtime of an MDX file as a Date object.
  * Caller receives the Date directly — no string round-trip, no re-parse needed.
  */
 async function getFileLastModifiedDate(absoluteFilePath: string): Promise<Date | undefined> {
+  if (fileMtimeCache.has(absoluteFilePath)) {
+    return fileMtimeCache.get(absoluteFilePath);
+  }
   try {
     const stat = await fsPromises.stat(absoluteFilePath);
-    return stat.mtime;
+    const mtime = stat.mtime;
+    fileMtimeCache.set(absoluteFilePath, mtime); // Cache result for future calls
+    return mtime;
   } catch {
     return undefined;
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@docsearch/css": "^4.6.2",
     "@docsearch/react": "^4.6.2",
-    "@docubook/core": "^1.3.1",
+    "@docubook/core": "^1.3.2",
     "@docubook/mdx-content": "^2.0.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   ],
   "scripts": {
     "build": "turbo build",
+    "build:next:docker": "turbo build --filter=docubook-next-docker",
+    "build:next:vercel": "turbo build --filter=docubook-next",
     "dev:web": "turbo dev --filter=@docubook/web",
-    "dev:next:docker": "turbo dev --filter=docubook-next-docker",
-    "dev:next:vercel": "turbo dev --filter=docubook-next",
     "lint": "turbo lint",
     "clean": "turbo clean",
     "typecheck": "turbo typecheck",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
   ],
   "scripts": {
     "build": "turbo build",
-    "build:next:docker": "turbo build --filter=docubook-next-docker",
-    "build:next:vercel": "turbo build --filter=docubook-next",
     "dev:web": "turbo dev --filter=@docubook/web",
     "lint": "turbo lint",
     "clean": "turbo clean",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @docubook/core
 
+## 1.3.2
+
+### Patch Changes
+
+- 2b84be1: Fix file reading logic in `readMdxFileBySlug` to try all candidate paths before failing:
+  - Change catch block in the path loop from throwing error immediately to continuing to the next
+    path, ensuring both `${slug}.mdx` and `slug/index.mdx` are attempted before throwing "Could not
+    find mdx file".
+  - This prevents premature failures when the file exists in the second path (e.g., `slug/index.mdx`
+    for folder-based slugs).
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docubook/core",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "Shared MDX compile pipeline and markdown utilities for DocuBook",
     "type": "module",
     "main": "./dist/index.js",

--- a/packages/core/src/content.ts
+++ b/packages/core/src/content.ts
@@ -33,6 +33,10 @@ type ReadMdxBySlugOptions = {
 };
 
 export async function readMdxFileBySlug(slug: string, options: ReadMdxBySlugOptions = {}): Promise<ReadMdxFileResult> {
+    if (!slug || slug.trim() === "") {
+        // Handle root slug as "index"
+        slug = "index";
+    }
     const docsDir = options.docsDir ?? "docs";
     // Keep file-system path operations ignored by Turbopack tracing.
     // The runtime path is constrained to docsDir and slug candidates below.
@@ -41,7 +45,6 @@ export async function readMdxFileBySlug(slug: string, options: ReadMdxBySlugOpti
         : path.join(/*turbopackIgnore: true*/ process.cwd(), docsDir);
 
     // Resolve once for path-traversal guard — all candidate paths must stay
-    // inside docsRoot. This prevents "../../etc/passwd" style slugs from
     // escaping the docs directory, especially important with dynamicParams=true.
     const resolvedRoot = path.resolve(/*turbopackIgnore: true*/ docsRoot);
 
@@ -49,6 +52,7 @@ export async function readMdxFileBySlug(slug: string, options: ReadMdxBySlugOpti
         path.join(/*turbopackIgnore: true*/ docsRoot, `${slug}.mdx`),
         path.join(/*turbopackIgnore: true*/ docsRoot, slug, "index.mdx"),
     ];
+    // console.log(`Attempting to read slug: "${slug}", paths:`, paths); // Debug log
     const attempted: string[] = [];
 
     for (const p of paths) {
@@ -63,8 +67,8 @@ export async function readMdxFileBySlug(slug: string, options: ReadMdxBySlugOpti
             const content = await fs.readFile(/*turbopackIgnore: true*/ p, "utf-8");
             return { content, filePath: `${docsDir}/${path.relative(/*turbopackIgnore: true*/ docsRoot, p)}`, absoluteFilePath: p };
         } catch (error) {
-            console.error(`Failed to read file ${p}:`, error);
-            throw new Error(`Could not read mdx file: ${slug}`);
+            // Continue to next path if this one fails
+            continue;
         }
     }
 

--- a/packages/template/nextjs-docker/lib/markdown.ts
+++ b/packages/template/nextjs-docker/lib/markdown.ts
@@ -30,14 +30,21 @@ export type BaseMdxFrontmatter = {
 // `React.cache` deduplicates calls within a single server-render pass.
 // Keep request-level cache in app layer, while markdown pipeline lives in core.
 
+const fileMtimeCache = new Map<string, Date>();
+
 /**
  * Return the mtime of an MDX file as a Date object.
  * Caller receives the Date directly — no string round-trip, no re-parse needed.
  */
 async function getFileLastModifiedDate(absoluteFilePath: string): Promise<Date | undefined> {
+  if (fileMtimeCache.has(absoluteFilePath)) {
+    return fileMtimeCache.get(absoluteFilePath);
+  }
   try {
     const stat = await fsPromises.stat(absoluteFilePath);
-    return stat.mtime;
+    const mtime = stat.mtime;
+    fileMtimeCache.set(absoluteFilePath, mtime); // Cache result for future calls
+    return mtime;
   } catch {
     return undefined;
   }

--- a/packages/template/nextjs-docker/package.json
+++ b/packages/template/nextjs-docker/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@docsearch/css": "^4.6.2",
     "@docsearch/react": "^4.6.2",
-    "@docubook/core": "^1.3.0",
+    "@docubook/core": "^1.3.2",
     "@docubook/mdx-content": "^2.0.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/packages/template/nextjs-vercel/lib/markdown.ts
+++ b/packages/template/nextjs-vercel/lib/markdown.ts
@@ -30,14 +30,21 @@ export type BaseMdxFrontmatter = {
 // `React.cache` deduplicates calls within a single server-render pass.
 // Keep request-level cache in app layer, while markdown pipeline lives in core.
 
+const fileMtimeCache = new Map<string, Date>();
+
 /**
  * Return the mtime of an MDX file as a Date object.
  * Caller receives the Date directly — no string round-trip, no re-parse needed.
  */
 async function getFileLastModifiedDate(absoluteFilePath: string): Promise<Date | undefined> {
+  if (fileMtimeCache.has(absoluteFilePath)) {
+    return fileMtimeCache.get(absoluteFilePath);
+  }
   try {
     const stat = await fsPromises.stat(absoluteFilePath);
-    return stat.mtime;
+    const mtime = stat.mtime;
+    fileMtimeCache.set(absoluteFilePath, mtime); // Cache result for future calls
+    return mtime;
   } catch {
     return undefined;
   }

--- a/packages/template/nextjs-vercel/package.json
+++ b/packages/template/nextjs-vercel/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@docsearch/css": "^4.6.2",
     "@docsearch/react": "^4.6.2",
-    "@docubook/core": "^1.3.0",
+    "@docubook/core": "^1.3.2",
     "@docubook/mdx-content": "^2.0.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^4.6.2
         version: 4.6.2(@algolia/client-search@5.50.0)(@types/react@19.2.8)(algoliasearch@5.50.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)
       '@docubook/core':
-        specifier: ^1.3.1
-        version: 1.3.1(@types/react@19.2.8)(react@19.2.3)
+        specifier: ^1.3.2
+        version: 1.3.2(@types/react@19.2.8)(react@19.2.3)
       '@docubook/mdx-content':
         specifier: ^2.0.0
         version: 2.0.0(lucide-react@1.7.0(react@19.2.3))(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-icons@5.6.0(react@19.2.3))(react@19.2.3)
@@ -529,8 +529,8 @@ packages:
       search-insights:
         optional: true
 
-  '@docubook/core@1.3.1':
-    resolution: {integrity: sha512-g0M6S+ZGR5iX0s/MrzqY3Z64dKBCWf3wbt1ho8Mssrdm4W2dE7BJY598T7NOavY8zr2jkncmfLEAAoJzOsIf8A==}
+  '@docubook/core@1.3.2':
+    resolution: {integrity: sha512-uyrjWk/WHwq+/uBfNOkmqnPtCFr5pBh4HcLX/8urVxXsJ43eqbkAm06CUPdOAhwYlql6xefKwQwrXD3qP7XaeA==}
 
   '@docubook/docs-tree@1.0.1':
     resolution: {integrity: sha512-AmsrlXeACyWX09RCQF46E/PWHbaTql8OTyBAdz6nKlg4SiZIHi1A4k4ELjw0dZKNfzl1Dt7PUS/E0w52l0al4g==}
@@ -4406,7 +4406,7 @@ snapshots:
       - '@algolia/client-search'
       - algoliasearch
 
-  '@docubook/core@1.3.1(@types/react@19.2.8)(react@19.2.3)':
+  '@docubook/core@1.3.2(@types/react@19.2.8)(react@19.2.3)':
     dependencies:
       gray-matter: 4.0.3
       next-mdx-remote: 6.0.0(@types/react@19.2.8)(react@19.2.3)


### PR DESCRIPTION
# @docubook/core

## 1.3.2

### Patch Changes

- 2b84be1: Fix file reading logic in `readMdxFileBySlug` to try all candidate paths before failing:
  - Change catch block in the path loop from throwing error immediately to continuing to the next
    path, ensuring both `${slug}.mdx` and `slug/index.mdx` are attempted before throwing "Could not
    find mdx file".
  - This prevents premature failures when the file exists in the second path (e.g., `slug/index.mdx`
    for folder-based slugs).