### PR TITLE
refactor(cli): remove dead getVersion import from renderer.js

### DIFF
--- a/packages/cli/src/tui/renderer.js
+++ b/packages/cli/src/tui/renderer.js
@@ -1,10 +1,7 @@
 import { colors, success, info, loading, dim } from './colors.js';
 import { createWelcomeBanner, createScaffoldingBanner, createSuccessBanner, createBoxedMessage } from './ascii.js';
-import { getVersion } from '../utils/version.js';
 
-const version = getVersion();
-
-export function renderWelcome() {
+export function renderWelcome(version) {
   console.clear();
   console.log('');
   console.log(createWelcomeBanner(version));


### PR DESCRIPTION
Fixes #128

Removed the unused `getVersion` import and module-level `version` variable from `renderer.js`. Made `renderWelcome` accept `version` as a parameter — which `program.js` already passes as an argument.

**Changes**: `packages/cli/src/tui/renderer.js` — 1 insertion, 4 deletions