### PR TITLE
fix(cli): handle coming-soon templates consistently

### DIFF
--- a/packages/cli/src/cli/program.js
+++ b/packages/cli/src/cli/program.js
@@ -95,6 +95,12 @@ export function initializeProgram(version) {
             );
           }
 
+          if (tmpl.status === "coming-soon") {
+            throw new Error(
+              `Template "${selectedTemplate}" is coming soon and not yet available.`
+            );
+          }
+
           state.setTemplate(tmpl.name);
         } else {
           throw new Error("No templates available");

--- a/packages/cli/src/cli/promptHandler.js
+++ b/packages/cli/src/cli/promptHandler.js
@@ -58,9 +58,10 @@ export async function collectUserInput(cliProvidedDir) {
       name: "template",
       message: "Select your template:",
       choices: availableTemplates.map((template) => ({
-        title: template.name,
+        title: template.status === "coming-soon" ? `${template.name} (Coming Soon)` : template.name,
         description: template.description,
         value: template.id,
+        disabled: template.status === "coming-soon",
       })),
       initial: 0,
     },

--- a/packages/cli/src/utils/templateDetect.js
+++ b/packages/cli/src/utils/templateDetect.js
@@ -47,6 +47,7 @@ export function getAvailableTemplates() {
         description: config.description,
         features: config.features,
         base: config.base || null,
+        status: config.status || null,
       });
     } catch {
       console.error(`Failed to read template config for ${entry.name}`);

--- a/packages/cli/templates.json
+++ b/packages/cli/templates.json
@@ -40,6 +40,7 @@
       "id": "react-router",
       "name": "react-router",
       "description": "Client-side documentation with React Router",
+      "status": "coming-soon",
       "features": [
         "React 19",
         "React Router v6",


### PR DESCRIPTION
## Summary

Fixes #99 — CLI now properly handles templates with `status: "coming-soon"`.

## Changes

- **`templates.json`**: Added `"status": "coming-soon"` to the react-router template entry
- **`templateDetect.js`**: Fallback scanner now propagates the `status` field from `template.config.json`
- **`promptHandler.js`**: Templates with `coming-soon` status are shown with a `(Coming Soon)` suffix and marked as `disabled` in the interactive prompt
- **`program.js`**: CLI argument validation rejects `coming-soon` templates with a clear error message

## Verification

- All existing tests pass (10/10)
- No new lint errors introduced (pre-existing errors remain unchanged)