### PR TITLE
refactor(core): safe two-pass tree mutation in handleCodeTitles

### DIFF
--- a/packages/core/src/plugins/handleCodeTitles.ts
+++ b/packages/core/src/plugins/handleCodeTitles.ts
@@ -8,6 +8,8 @@ interface TextNode extends Node {
 }
 
 export const handleCodeTitles = () => (tree: Node) => {
+  const toRemove: { parent: Parent; index: number }[] = []
+
   visit(tree, "element", (node: ElementNode, index: number | null, parent: Parent | null) => {
     if (!parent || index === null || node.tagName !== "div") {
       return
@@ -35,9 +37,14 @@ export const handleCodeTitles = () => (tree: Node) => {
         }
         nextElement.properties["data-title"] = titleNode.value
         nextElement.codeTitle = titleNode.value
-        parent.children.splice(index, 1)
-        return index
+        toRemove.push({ parent, index })
       }
     }
   })
+
+  // Remove title divs in reverse order to preserve indices
+  for (let i = toRemove.length - 1; i >= 0; i--) {
+    const { parent, index } = toRemove[i]
+    parent.children.splice(index, 1)
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #110 — Refactors `handleCodeTitles` to avoid mutating the tree during `visit()` iteration.

## Changes

Replaced the in-place `splice` + `return index` pattern with a two-pass approach:
1. **First pass**: Visits the tree, transfers title data to `<pre>` elements, and collects indices of title divs to remove
2. **Second pass**: Removes collected divs in reverse order (preserving indices)

This eliminates undefined behavior from mid-visit tree mutation and removes the dead `return index` statement.

## Verification

All 42 core tests pass.