### PR TITLE
fix(packages): add lint and build validation to pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,24 @@
+echo "🔍 Running lint checks..."
+pnpm turbo lint || {
+  echo ""
+  echo "🚫 Push rejected: lint errors found."
+  echo "   Run 'pnpm turbo lint' locally to see details."
+  echo ""
+  exit 1
+}
+
+echo ""
+echo "🔨 Running build checks..."
+pnpm turbo build || {
+  echo ""
+  echo "🚫 Push rejected: build failed."
+  echo "   Run 'pnpm turbo build' locally to see details."
+  echo ""
+  exit 1
+}
+
+echo ""
+echo "📝 Validating commit messages..."
 pnpm exec commitlint --from $(git rev-parse @{push} 2>/dev/null || git rev-parse origin/main 2>/dev/null || echo HEAD~1) --to HEAD --verbose || {
   echo ""
   echo "🚫 Push rejected: commit message does not follow conventional commit rules."


### PR DESCRIPTION
## Summary

Resolves #179 — The pre-push hook now validates lint and build before allowing a push.

## Changes

Updated `.husky/pre-push` to run three sequential checks:

1. **Lint** (`pnpm turbo lint`) — catches ESLint errors
2. **Build** (`pnpm turbo build`) — catches compilation/type errors
3. **Commitlint** — validates commit message format (existing)

Each phase fails fast with a clear error message and actionable guidance.

## Push Flow

```
git push
  → 🔍 Lint check (turbo lint)
  → 🔨 Build check (turbo build)
  → 📝 Commit message validation (commitlint)
  → ✅ Push proceeds
```

## Verification

- [x] Hook is executable (`chmod +x`)
- [x] Each phase exits with code 1 on failure
- [x] Commitlint error messages preserved from original hook