### PR TITLE
docs(flame): use bun commands in quick-start and installation guides

### DIFF
--- a/packages/flame/docs/getting-started/installation.mdx
+++ b/packages/flame/docs/getting-started/installation.mdx
@@ -3,7 +3,7 @@ title: Installation
 description: Installation guide for our application.
 ---
 
-Setting up DocuBook is straightforward, with options to clone the repository or use the convenient `npx` command. DocuBook requires [Node.js](https://nodejs.org/) version 18 or higher for optimal performance.
+Setting up DocuBook is straightforward, with options to clone the repository or use the convenient `npx` command. DocuBook Flame requires [Bun](https://bun.sh/) version 1.0 or higher. For other templates, [Node.js](https://nodejs.org/) version 18 or higher is supported.
 
 ## Quick Setup with CLI
 

--- a/packages/flame/docs/getting-started/quick-start-guide.mdx
+++ b/packages/flame/docs/getting-started/quick-start-guide.mdx
@@ -14,10 +14,7 @@ Before we begin, ensure you have the following installed:
     install [Git-scm](https://git-scm.com/)
   </Step>
   <Step title="Runtime JavaScript">
-    install [Node.js 18+](https://nodejs.org/) or [Bun 1.0+](https://bun.sh/)
-  </Step>
-  <Step title="Use PM">
-    A package manager (npm, yarn, or pnpm)
+    install [Bun 1.0+](https://bun.sh/) (recommended) or [Node.js 18+](https://nodejs.org/)
   </Step>
 </Steps>
 
@@ -125,10 +122,6 @@ docs/                    # Main documentation directory
 Start the development server with live reload:
 
 ```bash
-# Using npm
-npm run dev
-
-# Or using Bun
 bun dev
 ```
 
@@ -140,8 +133,8 @@ When ready to deploy:
 
 ```bash
 # Build the production version
-npm run build
+bun run build
 
-# Start the production server
-npm start
+# Preview the production build
+bun preview
 ```


### PR DESCRIPTION
## Summary

Resolves #177 — Quick-start guide and installation docs now use Bun commands as the primary workflow for Flame.

## Changes

### `quick-start-guide.mdx`
- Prerequisites: Bun listed as primary runtime, removed separate "package manager" step (Bun is both)
- Dev command: `bun dev` (was `npm run dev`)
- Build command: `bun run build` (was `npm run build`)
- Preview command: `bun preview` (was `npm start`)

### `installation.mdx`
- Updated intro text to mention Bun 1.0+ as the requirement for Flame

## Verification

- [x] Commands match `packages/flame/package.json` scripts (`dev`, `build`, `preview`)
- [x] Prerequisites correctly list Bun as primary runtime