### PR TITLE
docs(cli): update react-router template status to 'in development'

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
   - **nextjs-vercel** : This template is optimized for deployment on Vercel (the default hosting target).
   - **nextjs-docker** : This template includes an opinionated Docker setup optimized for building a small, production-ready Next.js standalone image using multi-stage
     builds and an Alpine base.
-  - **react-router** : a minimal documentation template with SSR + Hydration (comingsoon)
+  - **react-router** : a minimal documentation template with SSR + Hydration (in development)
 
 ## Installation
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,7 +53,7 @@ The CLI will:
 
 - **Next.js - Vercel** : Next.js and Vercel deployment (optimized for vercel).
 - **Next.js - standalone** : Next.js standalone with Docker image (optimized for coolify, etc.).
-- **React Router** : Client-side app with React Router (coming soon)
+- **React Router** : Client-side app with React Router (in development)
 
 ## Package Manager Detection
 


### PR DESCRIPTION
## Summary

Resolves #183 — Updates the React Router template status from "coming soon" to "in development" in both READMEs.

## Context

The `packages/template/react-router/` directory exists with:
- `template.config.json` — template metadata
- `package.json` — dependencies and scripts defined
- `plan.md` — full implementation plan
- `README.md`

The template is registered in `templates.json` and shown in the CLI (currently disabled). The wording "coming soon" was misleading since the template is actively planned with a directory already scaffolded.

## Changes

- `packages/cli/README.md`: "(coming soon)" → "(in development)"
- `README.md`: "(comingsoon)" → "(in development)"

## Note

`templates.json` retains `"status": "coming-soon"` to keep the template disabled in the CLI until source code is implemented. This prevents users from selecting an incomplete template.