### PR TITLE
fix(flame): search indexing, error handling, and mobile navigation in Flame.

### DIFF
--- a/packages/flame/.docu/__tests__/search-indexer.test.ts
+++ b/packages/flame/.docu/__tests__/search-indexer.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from "vitest";
+import { stripJsx, extractRecords } from "../node/search-indexer";
+
+// Mock external & internal path modules to prevent extractRecords from throwing errors
+vi.mock("@docubook/core", () => ({
+  extractFrontmatterWithContent: <T>(raw: string) => {
+    // We cast to T to satisfy the generic constraint and avoid the unused-var error
+    const frontmatter = {
+      title: "Test Page",
+      description: "Test Description",
+    } as Record<string, string> as unknown as T;
+
+    // Simulates a simple frontmatter separation for testing purposes
+    if (raw.startsWith("---")) {
+      return {
+        frontmatter,
+        strippedContent: raw.replace(/---[\s\S]*?---/, "").trim(),
+      };
+    }
+    return {
+      frontmatter: {} as unknown as T,
+      strippedContent: raw,
+    };
+  },
+}));
+
+vi.mock("./paths", () => ({
+  DOCS_DIR: "/mock/docs",
+  ASSETS_DIR: "/mock/assets",
+  loadDocuConfig: () => ({
+    routes: [{ href: "/getting-started", title: "Getting Started" }],
+    meta: { title: "Docubook Docs" },
+  }),
+}));
+
+describe("Search Indexer Test Suite", () => {
+  // ==========================================
+  // UNIT TEST: stripJsx
+  // ==========================================
+  describe("stripJsx()", () => {
+    it("should remove inline self-closing components", () => {
+      const input = "Hello <Button label='Click' /> world";
+      expect(stripJsx(input)).toBe("Hello  world");
+    });
+
+    it("should remove paired components while preserving their inner text", () => {
+      const input = "This is an <Badge variant='success'>Important</Badge> text.";
+      expect(stripJsx(input)).toBe("This is an Important text.");
+    });
+
+    it("should successfully remove deeply nested components", () => {
+      const input = "Outer <Box><Card><Text>Inner</Text></Card></Box> End";
+      expect(stripJsx(input)).toBe("Outer Inner End");
+    });
+
+    it("should handle empty components", () => {
+      const input = "Start <Empty></Empty> Finish";
+      expect(stripJsx(input)).toBe("Start  Finish");
+    });
+
+    it("should leave content intact if no JSX is present", () => {
+      const input = "This is plain text without any components.";
+      expect(stripJsx(input)).toBe(input);
+    });
+  });
+
+  // ==========================================
+  // UNIT TEST: Table Row Skip
+  // ==========================================
+  describe("extractRecords() - Table Row Skip", () => {
+    it("should skip Markdown table rows so they are not indexed as content", () => {
+      const mdxContent = `
+# Table Heading
+| Header 1 | Header 2 |
+| -------- | -------- |
+| Row 1    | Data 1   |
+| Row 2    | Data 2   |
+
+Normal paragraph text after the table that should be indexed.
+      `;
+
+      const records = extractRecords("getting-started/page-1", mdxContent);
+
+      // Check if any markdown table rows accidentally got indexed
+      const tableContentRecord = records.find(
+        (r) =>
+          r.type === "content" && (r.content?.includes("Row 1") || r.content?.includes("Header 1"))
+      );
+
+      // Verify table rows DO NOT exist in the content records
+      expect(tableContentRecord).toBeUndefined();
+
+      // Verify the standard paragraph following the table is correctly indexed
+      const normalContentRecord = records.find(
+        (r) => r.type === "content" && r.content?.includes("Normal paragraph text")
+      );
+      expect(normalContentRecord).toBeDefined();
+    });
+  });
+
+  // ==========================================
+  // INTEGRATION TEST: JSX + Heading + Table Combination
+  // ==========================================
+  describe("extractRecords() - Complex Combination", () => {
+    it("should execute stripJsx before line parsing and correctly ignore tables", () => {
+      const mdxContent = `---
+title: Integration Guide
+---
+# <Icon name="setup" /> How to Setup
+
+Make sure to use the <Alert type="info">Don't forget to install bun</Alert> component first.
+
+| Feature | Status |
+| --- | --- |
+| JSX | Safe |
+
+## Final Subheading
+      `;
+
+      const records = extractRecords("getting-started/integration", mdxContent);
+
+      // 1. Verify paragraph content containing JSX
+      const contentRecords = records.filter((r) => r.type === "content");
+      const paragraphRecord = contentRecords.find((r) =>
+        r.content?.includes("Don't forget to install bun")
+      );
+
+      expect(paragraphRecord).toBeDefined();
+      // Ensure the <Alert> tags are stripped out but the inner text remains intact
+      expect(paragraphRecord?.content).not.toContain("<Alert>");
+      expect(paragraphRecord?.content).toContain(
+        "Make sure to use the Don't forget to install bun component first."
+      );
+
+      // 2. Ensure table rows are skipped entirely within a complex document layout
+      const hasTableText = records.some(
+        (r) => r.content?.includes("Feature") || r.content?.includes("Safe")
+      );
+      expect(hasTableText).toBe(false);
+    });
+  });
+});

--- a/packages/flame/.docu/components/Anchor.tsx
+++ b/packages/flame/.docu/components/Anchor.tsx
@@ -34,7 +34,7 @@ export default function Anchor({
 
   const activeClass = isActive ? activeClassName : "";
   const baseClasses = cn(
-    "text-blue-600 hover:text-blue-800 hover:underline transition-colors",
+    "hover:underline transition-colors",
     className,
     activeClass,
     disabled && "cursor-not-allowed opacity-50"

--- a/packages/flame/.docu/components/Search.tsx
+++ b/packages/flame/.docu/components/Search.tsx
@@ -217,16 +217,10 @@ function SearchTrigger({ onClick }: { onClick: () => void }) {
           <SearchIcon className="h-4 w-4 shrink-0" />
           <span className="flex-1 text-left">Search</span>
           <div className="flex items-center gap-0.5">
-            <Kbd
-              size="s"
-              className="bg-primary text-[12px text-base-300 dark:text-foreground rounded-md p-1.5 font-medium"
-            >
+            <Kbd className="bg-primary text-[12px text-base-300 dark:text-foreground rounded-md p-1.5 font-medium">
               <FnKey.Cmd />
             </Kbd>
-            <Kbd
-              size="s"
-              className="bg-primary text-base-300 dark:text-foreground rounded-md p-1.5 text-[12px] font-medium"
-            >
+            <Kbd className="bg-primary text-base-300 dark:text-foreground rounded-md p-1.5 text-[12px] font-medium">
               K
             </Kbd>
           </div>

--- a/packages/flame/.docu/components/Sidebar.tsx
+++ b/packages/flame/.docu/components/Sidebar.tsx
@@ -141,7 +141,11 @@ export function MobileBar({
             }
           >
             {(docuConfig.navbar?.menu || []).map((item) => (
-              <li key={item.href} className="text-base-content/80 hover:text-base-content">
+              <li
+                key={item.href}
+                role="menuitem"
+                className="text-base-content/80 hover:text-base-content hover:bg-base-200 cursor-pointer"
+              >
                 <Anchor
                   href={item.href}
                   activeWhen={(path: string) =>

--- a/packages/flame/.docu/components/Sidebar.tsx
+++ b/packages/flame/.docu/components/Sidebar.tsx
@@ -9,8 +9,9 @@ import {
   PanelRightClose,
   FileText,
 } from "lucide-react";
-import { Dropdown, DropdownLink } from "@docubook/ui-react/dropdown";
+import { Dropdown } from "@docubook/ui-react/dropdown";
 import { cn } from "../node/utils";
+import Anchor from "./Anchor";
 import { Context } from "./Context";
 import Menu from "./Menu";
 import { ThemeToggle } from "./Theme";
@@ -140,9 +141,18 @@ export function MobileBar({
             }
           >
             {(docuConfig.navbar?.menu || []).map((item) => (
-              <DropdownLink key={item.href} href={item.href}>
-                {item.title}
-              </DropdownLink>
+              <li key={item.href} className="text-base-content/80 hover:text-base-content">
+                <Anchor
+                  href={item.href}
+                  activeWhen={(path: string) =>
+                    path === item.href || path.startsWith(item.href + "/")
+                  }
+                  activeClassName="text-primary font-semibold"
+                  className="block rounded px-2 py-2 text-sm"
+                >
+                  {item.title}
+                </Anchor>
+              </li>
             ))}
           </Dropdown>
 

--- a/packages/flame/.docu/components/Social.tsx
+++ b/packages/flame/.docu/components/Social.tsx
@@ -79,7 +79,7 @@ const iconMap: Record<string, ReturnType<typeof createIcon>> = {
   mastodon: MastodonIcon,
 };
 
-function getIcon(name: string) {
+export function getSocialIcon(name: string) {
   const key = name.toLowerCase().replace(/\s+/g, "");
   return iconMap[key] || null;
 }
@@ -92,7 +92,7 @@ export default function Social({ className = "", size = 16 }: SocialProps) {
   return (
     <div className={`flex gap-1 ${className}`}>
       {socialLinks.map((link) => {
-        const Icon = getIcon(link.name);
+        const Icon = getSocialIcon(link.name);
         return (
           <a
             key={link.name}

--- a/packages/flame/.docu/components/Sublink.tsx
+++ b/packages/flame/.docu/components/Sublink.tsx
@@ -52,6 +52,7 @@ export default function Sublink({
       <div
         className={cn(
           "py-1.5",
+          level === 1 && "pl-4",
           level >= 2 && "border-l-2 pl-3",
           level >= 2 && (isActive ? "border-primary" : "border-base-300")
         )}

--- a/packages/flame/.docu/components/Sublink.tsx
+++ b/packages/flame/.docu/components/Sublink.tsx
@@ -52,7 +52,7 @@ export default function Sublink({
       <div
         className={cn(
           "py-1.5",
-          level === 1 && "pl-4",
+          level === 1 && "pl-2",
           level >= 2 && "border-l-2 pl-3",
           level >= 2 && (isActive ? "border-primary" : "border-base-300")
         )}
@@ -64,7 +64,7 @@ export default function Sublink({
 
   // Section with children
   return (
-    <div className="flex flex-col">
+    <div className={cn("flex flex-col", level === 1 && "pl-4")}>
       {/* Section header */}
       <button
         type="button"

--- a/packages/flame/.docu/components/Sublink.tsx
+++ b/packages/flame/.docu/components/Sublink.tsx
@@ -53,7 +53,7 @@ export default function Sublink({
         className={cn(
           "py-1.5",
           level === 1 && "pl-2",
-          level === 2 && "border-l-2 pl-6",
+          level === 2 && "border-l-2 pl-4",
           level === 2 && (isActive ? "border-primary" : "border-base-300"),
           level >= 3 && "border-l-2 pl-6",
           level >= 3 && (isActive ? "border-primary" : "border-base-300")

--- a/packages/flame/.docu/components/Sublink.tsx
+++ b/packages/flame/.docu/components/Sublink.tsx
@@ -53,8 +53,10 @@ export default function Sublink({
         className={cn(
           "py-1.5",
           level === 1 && "pl-2",
-          level >= 2 && "border-l-2 pl-3",
-          level >= 2 && (isActive ? "border-primary" : "border-base-300")
+          level === 2 && "border-l-2 pl-3",
+          level === 2 && (isActive ? "border-primary" : "border-base-300"),
+          level >= 3 && "border-l-2 pl-6",
+          level >= 3 && (isActive ? "border-primary" : "border-base-300")
         )}
       >
         {link}

--- a/packages/flame/.docu/components/Sublink.tsx
+++ b/packages/flame/.docu/components/Sublink.tsx
@@ -66,7 +66,14 @@ export default function Sublink({
 
   // Section with children
   return (
-    <div className={cn("flex flex-col", level === 1 && "pl-2")}>
+    <div
+      className={cn(
+        "flex flex-col",
+        level === 1 && "pl-2",
+        level === 2 && "pl-4",
+        level >= 3 && "pl-6"
+      )}
+    >
       {/* Section header */}
       <button
         type="button"

--- a/packages/flame/.docu/components/Sublink.tsx
+++ b/packages/flame/.docu/components/Sublink.tsx
@@ -64,7 +64,7 @@ export default function Sublink({
 
   // Section with children
   return (
-    <div className={cn("flex flex-col", level === 1 && "pl-4")}>
+    <div className={cn("flex flex-col", level === 1 && "pl-2")}>
       {/* Section header */}
       <button
         type="button"

--- a/packages/flame/.docu/components/Sublink.tsx
+++ b/packages/flame/.docu/components/Sublink.tsx
@@ -53,7 +53,7 @@ export default function Sublink({
         className={cn(
           "py-1.5",
           level === 1 && "pl-2",
-          level === 2 && "border-l-2 pl-3",
+          level === 2 && "border-l-2 pl-6",
           level === 2 && (isActive ? "border-primary" : "border-base-300"),
           level >= 3 && "border-l-2 pl-6",
           level >= 3 && (isActive ? "border-primary" : "border-base-300")

--- a/packages/flame/.docu/components/Sublink.tsx
+++ b/packages/flame/.docu/components/Sublink.tsx
@@ -33,6 +33,9 @@ export default function Sublink({
     return currentPathname.startsWith(fullHref) && currentPathname !== fullHref;
   });
 
+  // Shared padding based on nesting level
+  const levelPadding = cn(level === 1 && "pl-2", level === 2 && "pl-4", level >= 3 && "pl-6");
+
   // Leaf node (no children)
   if (!items) {
     const isActive = currentPathname === fullHref || currentPathname === `${fullHref}.html`;
@@ -52,11 +55,9 @@ export default function Sublink({
       <div
         className={cn(
           "py-1.5",
-          level === 1 && "pl-2",
-          level === 2 && "border-l-2 pl-4",
-          level === 2 && (isActive ? "border-primary" : "border-base-300"),
-          level >= 3 && "border-l-2 pl-6",
-          level >= 3 && (isActive ? "border-primary" : "border-base-300")
+          levelPadding,
+          level >= 2 && "border-l-2",
+          level >= 2 && (isActive ? "border-primary" : "border-base-300")
         )}
       >
         {link}
@@ -66,14 +67,7 @@ export default function Sublink({
 
   // Section with children
   return (
-    <div
-      className={cn(
-        "flex flex-col",
-        level === 1 && "pl-2",
-        level === 2 && "pl-4",
-        level >= 3 && "pl-6"
-      )}
-    >
+    <div className={cn("flex flex-col", levelPadding)}>
       {/* Section header */}
       <button
         type="button"

--- a/packages/flame/.docu/components/home/Features.tsx
+++ b/packages/flame/.docu/components/home/Features.tsx
@@ -60,7 +60,7 @@ function FeatureCard({ feature }: FeatureCardProps) {
           </div>
         )}
         <h3 className="mb-2 text-lg font-semibold">{feature.title}</h3>
-        <p className="text-base-content/70 text-sm">{feature.description}</p>
+        <p className="text-muted-foreground text-sm">{feature.description}</p>
       </div>
     </Wrapper>
   );

--- a/packages/flame/.docu/components/home/Features.tsx
+++ b/packages/flame/.docu/components/home/Features.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import * as icons from "lucide-react";
+import type { HomeFeature } from "../../node/types";
+import { cn } from "../../node/utils";
+
+interface FeaturesProps {
+  features: HomeFeature[];
+  className?: string;
+}
+
+interface FeatureCardProps {
+  feature: HomeFeature;
+}
+
+function FeatureCard({ feature }: FeatureCardProps) {
+  const Icon = feature.icon
+    ? (icons as unknown as Record<string, icons.LucideIcon>)[feature.icon]
+    : null;
+
+  const Wrapper = feature.link ? "a" : "div";
+  const wrapperProps = feature.link ? { href: feature.link } : {};
+
+  return (
+    <Wrapper
+      {...wrapperProps}
+      className={cn(
+        "border-base-200 bg-base-100 hover:border-primary/40 group rounded-2xl border p-6 transition-all hover:shadow-lg",
+        feature.link && "cursor-pointer"
+      )}
+    >
+      {Icon && (
+        <div className="bg-primary/10 mb-4 inline-flex h-12 w-12 items-center justify-center rounded-lg">
+          <Icon className="text-primary h-6 w-6" />
+        </div>
+      )}
+      <h3 className="mb-2 text-lg font-semibold">{feature.title}</h3>
+      <p className="text-base-content/70 text-sm">{feature.description}</p>
+    </Wrapper>
+  );
+}
+
+export function Features({ features, className }: FeaturesProps) {
+  if (!features || features.length === 0) return null;
+
+  return (
+    <div className={cn("mx-auto max-w-5xl px-6 pb-24", className)}>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {features.map((feature, index) => (
+          <FeatureCard key={index} feature={feature} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/flame/.docu/components/home/Features.tsx
+++ b/packages/flame/.docu/components/home/Features.tsx
@@ -21,6 +21,9 @@ function FeatureCard({ feature }: FeatureCardProps) {
   const Wrapper = feature.link ? "a" : "div";
   const wrapperProps = feature.link ? { href: feature.link } : {};
 
+  // Sanitize pattern ID to remove spaces
+  const patternId = `grid-${feature.title}`.replace(/\s+/g, "-");
+
   return (
     <Wrapper
       {...wrapperProps}
@@ -36,12 +39,7 @@ function FeatureCard({ feature }: FeatureCardProps) {
         style={{ color: "var(--color-primary)" }}
       >
         <defs>
-          <pattern
-            id={`grid-${feature.title}`}
-            width="40"
-            height="40"
-            patternUnits="userSpaceOnUse"
-          >
+          <pattern id={patternId} width="40" height="40" patternUnits="userSpaceOnUse">
             <path
               d="M 40 0 L 0 0 0 40"
               fill="none"
@@ -51,7 +49,7 @@ function FeatureCard({ feature }: FeatureCardProps) {
             />
           </pattern>
         </defs>
-        <rect width="100%" height="100%" fill={`url(#grid-${feature.title})`} />
+        <rect width="100%" height="100%" fill={`url(#${patternId})`} />
       </svg>
 
       {/* Content */}

--- a/packages/flame/.docu/components/home/Features.tsx
+++ b/packages/flame/.docu/components/home/Features.tsx
@@ -30,10 +30,7 @@ function FeatureCard({ feature }: FeatureCardProps) {
       )}
     >
       {/* Grid pattern background */}
-      <svg
-        className="text-base-300/50 absolute inset-0 h-full w-full"
-        xmlns="http://www.w3.org/2000/svg"
-      >
+      <svg className="absolute inset-0 h-full w-full" xmlns="http://www.w3.org/2000/svg">
         <defs>
           <pattern
             id={`grid-${feature.title}`}
@@ -41,7 +38,13 @@ function FeatureCard({ feature }: FeatureCardProps) {
             height="40"
             patternUnits="userSpaceOnUse"
           >
-            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="currentColor" strokeWidth="0.5" />
+            <path
+              d="M 40 0 L 0 0 0 40"
+              fill="none"
+              stroke="#d1d5db"
+              strokeWidth="0.5"
+              opacity="0.5"
+            />
           </pattern>
         </defs>
         <rect width="100%" height="100%" fill={`url(#grid-${feature.title})`} />

--- a/packages/flame/.docu/components/home/Features.tsx
+++ b/packages/flame/.docu/components/home/Features.tsx
@@ -25,7 +25,7 @@ function FeatureCard({ feature }: FeatureCardProps) {
     <Wrapper
       {...wrapperProps}
       className={cn(
-        "border-primary/20 bg-primary/5 hover:border-primary/40 group relative overflow-hidden rounded-2xl border transition-all",
+        "border-base-200 bg-base-100 hover:border-primary/40 group relative overflow-hidden rounded-2xl border p-6 transition-all hover:shadow-lg",
         feature.link && "cursor-pointer"
       )}
     >
@@ -43,7 +43,7 @@ function FeatureCard({ feature }: FeatureCardProps) {
               fill="none"
               stroke="currentColor"
               strokeWidth="0.5"
-              className="text-primary/15"
+              className="text-base-300/50"
             />
           </pattern>
         </defs>
@@ -51,10 +51,10 @@ function FeatureCard({ feature }: FeatureCardProps) {
       </svg>
 
       {/* Content */}
-      <div className="relative z-10 flex flex-col items-center p-6 text-center">
+      <div className="relative z-10">
         {Icon && (
-          <div className="mb-4">
-            <Icon className="text-primary h-16 w-16" strokeWidth={1} />
+          <div className="bg-primary/10 mb-4 inline-flex h-12 w-12 items-center justify-center rounded-lg">
+            <Icon className="text-primary h-6 w-6" />
           </div>
         )}
         <h3 className="mb-2 text-lg font-semibold">{feature.title}</h3>

--- a/packages/flame/.docu/components/home/Features.tsx
+++ b/packages/flame/.docu/components/home/Features.tsx
@@ -30,7 +30,11 @@ function FeatureCard({ feature }: FeatureCardProps) {
       )}
     >
       {/* Grid pattern background */}
-      <svg className="absolute inset-0 h-full w-full" xmlns="http://www.w3.org/2000/svg">
+      <svg
+        className="absolute inset-0 h-full w-full"
+        xmlns="http://www.w3.org/2000/svg"
+        style={{ color: "var(--color-base-300)" }}
+      >
         <defs>
           <pattern
             id={`grid-${feature.title}`}
@@ -41,7 +45,7 @@ function FeatureCard({ feature }: FeatureCardProps) {
             <path
               d="M 40 0 L 0 0 0 40"
               fill="none"
-              stroke="#d1d5db"
+              stroke="currentColor"
               strokeWidth="0.5"
               opacity="0.5"
             />

--- a/packages/flame/.docu/components/home/Features.tsx
+++ b/packages/flame/.docu/components/home/Features.tsx
@@ -33,7 +33,7 @@ function FeatureCard({ feature }: FeatureCardProps) {
       <svg
         className="absolute inset-0 h-full w-full"
         xmlns="http://www.w3.org/2000/svg"
-        style={{ color: "var(--color-base-300)" }}
+        style={{ color: "var(--color-primary)" }}
       >
         <defs>
           <pattern
@@ -47,7 +47,7 @@ function FeatureCard({ feature }: FeatureCardProps) {
               fill="none"
               stroke="currentColor"
               strokeWidth="0.5"
-              opacity="0.5"
+              opacity="0.15"
             />
           </pattern>
         </defs>

--- a/packages/flame/.docu/components/home/Features.tsx
+++ b/packages/flame/.docu/components/home/Features.tsx
@@ -25,17 +25,41 @@ function FeatureCard({ feature }: FeatureCardProps) {
     <Wrapper
       {...wrapperProps}
       className={cn(
-        "border-base-200 bg-base-100 hover:border-primary/40 group rounded-2xl border p-6 transition-all hover:shadow-lg",
+        "border-primary/20 bg-primary/5 hover:border-primary/40 group relative overflow-hidden rounded-2xl border transition-all",
         feature.link && "cursor-pointer"
       )}
     >
-      {Icon && (
-        <div className="bg-primary/10 mb-4 inline-flex h-12 w-12 items-center justify-center rounded-lg">
-          <Icon className="text-primary h-6 w-6" />
-        </div>
-      )}
-      <h3 className="mb-2 text-lg font-semibold">{feature.title}</h3>
-      <p className="text-base-content/70 text-sm">{feature.description}</p>
+      {/* Grid pattern background */}
+      <svg className="absolute inset-0 h-full w-full" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <pattern
+            id={`grid-${feature.title}`}
+            width="40"
+            height="40"
+            patternUnits="userSpaceOnUse"
+          >
+            <path
+              d="M 40 0 L 0 0 0 40"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="0.5"
+              className="text-primary/15"
+            />
+          </pattern>
+        </defs>
+        <rect width="100%" height="100%" fill={`url(#grid-${feature.title})`} />
+      </svg>
+
+      {/* Content */}
+      <div className="relative z-10 flex flex-col items-center p-6 text-center">
+        {Icon && (
+          <div className="mb-4">
+            <Icon className="text-primary h-16 w-16" strokeWidth={1} />
+          </div>
+        )}
+        <h3 className="mb-2 text-lg font-semibold">{feature.title}</h3>
+        <p className="text-base-content/70 text-sm">{feature.description}</p>
+      </div>
     </Wrapper>
   );
 }

--- a/packages/flame/.docu/components/home/Features.tsx
+++ b/packages/flame/.docu/components/home/Features.tsx
@@ -30,7 +30,10 @@ function FeatureCard({ feature }: FeatureCardProps) {
       )}
     >
       {/* Grid pattern background */}
-      <svg className="absolute inset-0 h-full w-full" xmlns="http://www.w3.org/2000/svg">
+      <svg
+        className="text-base-300/50 absolute inset-0 h-full w-full"
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <defs>
           <pattern
             id={`grid-${feature.title}`}
@@ -38,13 +41,7 @@ function FeatureCard({ feature }: FeatureCardProps) {
             height="40"
             patternUnits="userSpaceOnUse"
           >
-            <path
-              d="M 40 0 L 0 0 0 40"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="0.5"
-              className="text-base-300/50"
-            />
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="currentColor" strokeWidth="0.5" />
           </pattern>
         </defs>
         <rect width="100%" height="100%" fill={`url(#grid-${feature.title})`} />

--- a/packages/flame/.docu/components/home/Hero.tsx
+++ b/packages/flame/.docu/components/home/Hero.tsx
@@ -36,15 +36,17 @@ function ActionButton({ action }: { action: HeroAction }) {
 }
 
 export function Hero({ hero, className }: HeroProps) {
-  const { name, text, tagline, image, actions } = hero;
+  const { tagline, headline, description, image, actions } = hero;
 
   return (
     <div className={cn("mx-auto max-w-4xl px-6 py-32 sm:py-44", className)}>
       <div className="text-center">
-        {name && <p className="text-primary mb-4 text-lg font-semibold">{name}</p>}
-        <h1 className="text-balance text-5xl font-semibold tracking-tight sm:text-7xl">{text}</h1>
-        {tagline && (
-          <p className="text-muted-foreground mt-8 text-pretty text-lg sm:text-xl">{tagline}</p>
+        {tagline && <p className="text-primary mb-4 text-lg font-semibold">{tagline}</p>}
+        <h1 className="text-balance text-5xl font-semibold tracking-tight sm:text-7xl">
+          {headline}
+        </h1>
+        {description && (
+          <p className="text-muted-foreground mt-8 text-pretty text-lg sm:text-xl">{description}</p>
         )}
         {actions && actions.length > 0 && (
           <div className="mt-10 flex flex-wrap items-center justify-center gap-4">

--- a/packages/flame/.docu/components/home/Hero.tsx
+++ b/packages/flame/.docu/components/home/Hero.tsx
@@ -23,7 +23,7 @@ function getIconComponent(iconName: string) {
 }
 
 function isExternalLink(link: string): boolean {
-  return /^(https?:\/\/|http:\/\/)/.test(link);
+  return /^https?:\/\//.test(link);
 }
 
 function ActionButton({ action }: { action: HeroAction }) {
@@ -35,12 +35,13 @@ function ActionButton({ action }: { action: HeroAction }) {
     ghost: "bg-transparent border border-base-300 hover:bg-base-200",
   };
 
-  const target = isExternalLink(action.link) ? "_blank" : undefined;
+  const isExternal = isExternalLink(action.link);
 
   return (
     <a
       href={action.link}
-      target={target}
+      target={isExternal ? "_blank" : undefined}
+      rel={isExternal ? "noopener noreferrer" : undefined}
       className={cn(
         "inline-flex items-center gap-2 rounded-lg px-6 py-3 text-sm font-medium transition-colors",
         themeClasses[action.theme || "primary"]

--- a/packages/flame/.docu/components/home/Hero.tsx
+++ b/packages/flame/.docu/components/home/Hero.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import * as icons from "lucide-react";
+import type { Hero as HeroType, HeroAction } from "../../node/types";
+import { cn } from "../../node/utils";
+
+interface HeroProps {
+  hero: HeroType;
+  className?: string;
+}
+
+function ActionButton({ action }: { action: HeroAction }) {
+  const Icon = action.icon
+    ? (icons as unknown as Record<string, icons.LucideIcon>)[action.icon]
+    : null;
+
+  const themeClasses = {
+    primary: "bg-primary text-primary-content hover:bg-primary/90",
+    secondary: "bg-secondary text-secondary-content hover:bg-secondary/90",
+    ghost: "bg-transparent border border-base-300 hover:bg-base-200",
+  };
+
+  return (
+    <a
+      href={action.link}
+      target={action.target}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-lg px-6 py-3 text-sm font-medium transition-colors",
+        themeClasses[action.theme || "primary"]
+      )}
+    >
+      {Icon && <Icon className="h-4 w-4" />}
+      {action.text}
+    </a>
+  );
+}
+
+export function Hero({ hero, className }: HeroProps) {
+  const { name, text, tagline, image, actions } = hero;
+
+  return (
+    <div className={cn("mx-auto max-w-4xl px-6 py-32 sm:py-44", className)}>
+      <div className="text-center">
+        {name && <p className="text-primary mb-4 text-lg font-semibold">{name}</p>}
+        <h1 className="text-balance text-5xl font-semibold tracking-tight sm:text-7xl">{text}</h1>
+        {tagline && (
+          <p className="text-muted-foreground mt-8 text-pretty text-lg sm:text-xl">{tagline}</p>
+        )}
+        {actions && actions.length > 0 && (
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+            {actions.map((action, index) => (
+              <ActionButton key={index} action={action} />
+            ))}
+          </div>
+        )}
+        {image && (
+          <div className="mt-12">
+            <img
+              src={image.src}
+              alt={image.alt || ""}
+              className="mx-auto max-h-64 rounded-lg object-contain"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/flame/.docu/components/home/Hero.tsx
+++ b/packages/flame/.docu/components/home/Hero.tsx
@@ -3,16 +3,27 @@
 import * as icons from "lucide-react";
 import type { Hero as HeroType, HeroAction } from "../../node/types";
 import { cn } from "../../node/utils";
+import { getSocialIcon } from "../Social";
 
 interface HeroProps {
   hero: HeroType;
   className?: string;
 }
 
+function getIconComponent(iconName: string) {
+  // First try lucide icons
+  const lucideIcon = (icons as unknown as Record<string, icons.LucideIcon>)[iconName];
+  if (lucideIcon) return lucideIcon;
+
+  // Then try social icons
+  const socialIcon = getSocialIcon(iconName);
+  if (socialIcon) return socialIcon;
+
+  return null;
+}
+
 function ActionButton({ action }: { action: HeroAction }) {
-  const Icon = action.icon
-    ? (icons as unknown as Record<string, icons.LucideIcon>)[action.icon]
-    : null;
+  const Icon = action.icon ? getIconComponent(action.icon) : null;
 
   const themeClasses = {
     primary: "bg-primary text-primary-content hover:bg-primary/90",

--- a/packages/flame/.docu/components/home/Hero.tsx
+++ b/packages/flame/.docu/components/home/Hero.tsx
@@ -22,6 +22,10 @@ function getIconComponent(iconName: string) {
   return null;
 }
 
+function isExternalLink(link: string): boolean {
+  return /^(https?:\/\/|http:\/\/)/.test(link);
+}
+
 function ActionButton({ action }: { action: HeroAction }) {
   const Icon = action.icon ? getIconComponent(action.icon) : null;
 
@@ -31,10 +35,12 @@ function ActionButton({ action }: { action: HeroAction }) {
     ghost: "bg-transparent border border-base-300 hover:bg-base-200",
   };
 
+  const target = isExternalLink(action.link) ? "_blank" : undefined;
+
   return (
     <a
       href={action.link}
-      target={action.target}
+      target={target}
       className={cn(
         "inline-flex items-center gap-2 rounded-lg px-6 py-3 text-sm font-medium transition-colors",
         themeClasses[action.theme || "primary"]
@@ -47,7 +53,7 @@ function ActionButton({ action }: { action: HeroAction }) {
 }
 
 export function Hero({ hero, className }: HeroProps) {
-  const { tagline, headline, description, image, actions } = hero;
+  const { tagline, headline, description, actions } = hero;
 
   return (
     <div className={cn("mx-auto max-w-4xl px-6 py-32 sm:py-44", className)}>
@@ -64,15 +70,6 @@ export function Hero({ hero, className }: HeroProps) {
             {actions.map((action, index) => (
               <ActionButton key={index} action={action} />
             ))}
-          </div>
-        )}
-        {image && (
-          <div className="mt-12">
-            <img
-              src={image.src}
-              alt={image.alt || ""}
-              className="mx-auto max-h-64 rounded-lg object-contain"
-            />
           </div>
         )}
       </div>

--- a/packages/flame/.docu/components/home/index.tsx
+++ b/packages/flame/.docu/components/home/index.tsx
@@ -1,0 +1,2 @@
+export { Hero } from "./Hero";
+export { Features } from "./Features";

--- a/packages/flame/.docu/components/registry.ts
+++ b/packages/flame/.docu/components/registry.ts
@@ -152,15 +152,13 @@ export function createComponentsRegistry(): Record<string, unknown> {
 export async function createFullComponentsRegistry(): Promise<Record<string, unknown>> {
   const baseComponents = createComponentsRegistry();
 
-  let mdxComponents: ComponentRegistry = {};
   try {
     const mdx = createMdxComponents() as unknown as ComponentRegistry;
-    mdxComponents = mdx;
-  } catch {
-    // MDX components not available
+    return { ...baseComponents, ...mdx };
+  } catch (error) {
+    console.error("Failed to load MDX components:", error);
+    return { ...baseComponents };
   }
-
-  return { ...baseComponents, ...mdxComponents };
 }
 
 export const componentsRegistry = createComponentsRegistry();

--- a/packages/flame/.docu/node/search-indexer.ts
+++ b/packages/flame/.docu/node/search-indexer.ts
@@ -56,7 +56,7 @@ function slugify(text: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-function stripJsx(content: string): string {
+export function stripJsx(content: string): string {
   let result = content;
   let prev = "";
   while (result !== prev) {
@@ -68,7 +68,7 @@ function stripJsx(content: string): string {
   return result;
 }
 
-function extractRecords(filePath: string, raw: string): SearchRecord[] {
+export function extractRecords(filePath: string, raw: string): SearchRecord[] {
   const { frontmatter, strippedContent: content } = extractFrontmatterWithContent<Frontmatter>(raw);
   const records: SearchRecord[] = [];
   const url = `/docs/${filePath}`;

--- a/packages/flame/.docu/node/search-indexer.ts
+++ b/packages/flame/.docu/node/search-indexer.ts
@@ -56,6 +56,18 @@ function slugify(text: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+function stripJsx(content: string): string {
+  let result = content;
+  let prev = "";
+  while (result !== prev) {
+    prev = result;
+    result = result
+      .replace(/<[A-Z][\w.]*[\s\S]*?\/>/g, "")
+      .replace(/<[A-Z][\w.]*[\s\S]*?>([\s\S]*?)<\/[A-Z][\w.]*>/g, "$1");
+  }
+  return result;
+}
+
 function extractRecords(filePath: string, raw: string): SearchRecord[] {
   const { frontmatter, strippedContent: content } = extractFrontmatterWithContent<Frontmatter>(raw);
   const records: SearchRecord[] = [];
@@ -82,7 +94,8 @@ function extractRecords(filePath: string, raw: string): SearchRecord[] {
     });
   }
 
-  const lines = content.split("\n");
+  const plainContent = stripJsx(content);
+  const lines = plainContent.split("\n");
   let currentParagraph: string[] = [];
   let inCodeBlock = false;
 
@@ -119,7 +132,6 @@ function extractRecords(filePath: string, raw: string): SearchRecord[] {
     if (inCodeBlock) continue;
 
     if (/^import\s+[\w{*]/.test(trimmed) || /^export\s+[\w{*]/.test(trimmed)) continue;
-    if (/^<\/?[A-Z][\w.]*[\s/>]/.test(trimmed) && !/>(.+)<\//.test(trimmed)) continue;
 
     const headingMatch = trimmed.match(/^(#{1,6})\s+(.+)$/);
     if (headingMatch) {
@@ -151,6 +163,8 @@ function extractRecords(filePath: string, raw: string): SearchRecord[] {
       flushParagraph();
       continue;
     }
+
+    if (/^\|.+\|/.test(trimmed)) continue;
 
     const cleaned = trimmed
       .replace(/^[-*+]\s+/, "") // list markers

--- a/packages/flame/.docu/node/types.ts
+++ b/packages/flame/.docu/node/types.ts
@@ -56,9 +56,9 @@ export interface HeroImage {
 }
 
 export interface Hero {
-  name?: string;
-  text: string;
   tagline?: string;
+  headline: string;
+  description?: string;
   image?: HeroImage;
   actions?: HeroAction[];
 }

--- a/packages/flame/.docu/node/types.ts
+++ b/packages/flame/.docu/node/types.ts
@@ -45,21 +45,12 @@ export interface HeroAction {
   link: string;
   theme?: "primary" | "secondary" | "ghost";
   icon?: string;
-  target?: string;
-}
-
-export interface HeroImage {
-  src: string;
-  alt?: string;
-  light?: string;
-  dark?: string;
 }
 
 export interface Hero {
   tagline?: string;
   headline: string;
   description?: string;
-  image?: HeroImage;
   actions?: HeroAction[];
 }
 

--- a/packages/flame/.docu/node/types.ts
+++ b/packages/flame/.docu/node/types.ts
@@ -40,8 +40,44 @@ export interface RepoConfig {
   edit: boolean;
 }
 
+export interface HeroAction {
+  text: string;
+  link: string;
+  theme?: "primary" | "secondary" | "ghost";
+  icon?: string;
+  target?: string;
+}
+
+export interface HeroImage {
+  src: string;
+  alt?: string;
+  light?: string;
+  dark?: string;
+}
+
+export interface Hero {
+  name?: string;
+  text: string;
+  tagline?: string;
+  image?: HeroImage;
+  actions?: HeroAction[];
+}
+
+export interface HomeFeature {
+  icon?: string;
+  title: string;
+  description: string;
+  link?: string;
+}
+
+export interface HomeConfig {
+  hero?: Hero;
+  features?: HomeFeature[];
+}
+
 export interface DocuConfig {
   meta: DocuMeta;
+  home?: HomeConfig;
   navbar: DocuNavbar;
   footer: DocuFooter;
   repo: RepoConfig;

--- a/packages/flame/.docu/node/utils.ts
+++ b/packages/flame/.docu/node/utils.ts
@@ -7,7 +7,8 @@ export function isExternalUrl(url: string): boolean {
 export function getPath(url: string): string {
   try {
     return new URL(url).pathname;
-  } catch {
+  } catch (err) {
+    console.error("Failed to parse URL", url, err);
     return url;
   }
 }
@@ -28,7 +29,8 @@ export async function getGitLastModified(filePath: string): Promise<string | nul
     const text = await new Response(proc.stdout).text();
     const date = text.trim();
     return date || null;
-  } catch {
+  } catch (err) {
+    console.error("Failed to get git last modified for", filePath, err);
     return null;
   }
 }
@@ -55,8 +57,8 @@ export async function getGitLastModifiedBatch(filePaths: string[]): Promise<Map<
         result.set(trimmed, currentDate);
       }
     }
-  } catch {
-    // fallback: return empty map, callers use frontmatter date
+  } catch (err) {
+    console.error("Failed to get git last modified batch for", filePaths, err);
   }
 
   return result;

--- a/packages/flame/.docu/pages/index.tsx
+++ b/packages/flame/.docu/pages/index.tsx
@@ -1,5 +1,6 @@
-import * as icons from "lucide-react";
 import { loadDocuConfig } from "../node/paths";
+import { Hero, Features } from "../components/home";
+import type { HomeFeature } from "../node/types";
 
 const docuConfig = loadDocuConfig();
 
@@ -17,9 +18,26 @@ interface RouteItem {
 }
 
 export default function IndexPage() {
-  const { meta } = docuConfig;
+  const { meta, home } = docuConfig;
   const routes = (docuConfig.routes as RouteItem[]) || [];
-  const cards = routes.filter((r) => r.context);
+
+  // Use home.features if configured, otherwise fallback to routes with context
+  const features: HomeFeature[] =
+    home?.features ||
+    routes
+      .filter((r) => r.context)
+      .map((route) => ({
+        icon: route.context?.icon,
+        title: route.context?.title || route.title,
+        description: route.context?.description || "",
+        link: `/docs${route.href}${route.items?.[0]?.href || ""}`,
+      }));
+
+  // Use home.hero if configured, otherwise fallback to meta
+  const hero = home?.hero || {
+    text: meta.title,
+    tagline: meta.description,
+  };
 
   return (
     <div className="bg-base-100 relative isolate min-h-screen overflow-hidden">
@@ -39,70 +57,11 @@ export default function IndexPage() {
         />
       </div>
 
-      {/* Hero */}
-      <div className="mx-auto max-w-2xl py-32 sm:py-44">
-        <div className="text-center">
-          <h1 className="text-balance text-5xl font-semibold tracking-tight sm:text-7xl">
-            {meta.title}
-          </h1>
-          <p className="text-muted-foreground mt-8 text-pretty text-lg sm:text-xl">
-            {meta.description}
-          </p>
-        </div>
-      </div>
+      {/* Hero Section */}
+      <Hero hero={hero} />
 
-      {/* Showcase Cards */}
-      {cards.length > 0 && (
-        <div className="relative mx-auto max-w-4xl px-6 pb-24">
-          <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
-            {cards.map((route) => {
-              const Icon = (icons as unknown as Record<string, icons.LucideIcon>)[
-                route.context!.icon || ""
-              ];
-              return (
-                <a
-                  key={route.href}
-                  href={`/docs${route.href}${route.items?.[0]?.href || ""}`}
-                  className="group"
-                >
-                  <div className="border-primary/20 bg-primary/5 group-hover:border-primary/40 relative flex aspect-[16/9] items-center justify-center overflow-hidden rounded-2xl border transition">
-                    {/* Grid pattern */}
-                    <svg
-                      className="absolute inset-0 h-full w-full"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <defs>
-                        <pattern
-                          id={`grid-${route.href}`}
-                          width="40"
-                          height="40"
-                          patternUnits="userSpaceOnUse"
-                        >
-                          <path
-                            d="M 40 0 L 0 0 0 40"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="0.5"
-                            className="text-primary/15"
-                          />
-                        </pattern>
-                      </defs>
-                      <rect width="100%" height="100%" fill={`url(#grid-${route.href})`} />
-                    </svg>
-                    {Icon && (
-                      <Icon className="text-primary relative z-10" size={80} strokeWidth={1} />
-                    )}
-                  </div>
-                  <h3 className="mt-4 text-lg font-semibold">
-                    {route.context!.title || route.title}
-                  </h3>
-                  <p className="text-muted-foreground text-m mt-1">{route.context!.description}</p>
-                </a>
-              );
-            })}
-          </div>
-        </div>
-      )}
+      {/* Features Section */}
+      <Features features={features} />
 
       {/* Bottom gradient blob */}
       <div

--- a/packages/flame/.docu/pages/index.tsx
+++ b/packages/flame/.docu/pages/index.tsx
@@ -35,8 +35,8 @@ export default function IndexPage() {
 
   // Use home.hero if configured, otherwise fallback to meta
   const hero = home?.hero || {
-    text: meta.title,
-    tagline: meta.description,
+    headline: meta.title,
+    description: meta.description,
   };
 
   return (

--- a/packages/flame/CHANGELOG.md
+++ b/packages/flame/CHANGELOG.md
@@ -1,0 +1,290 @@
+# @docubook/flame
+
+## 1.1.0
+
+### Minor Changes
+
+- feat(flame): add home page hero and features configuration
+  - Extend `docu.json` schema with `home.hero` and `home.features` sections
+  - Create `Hero` component with name, text, tagline, image, and action buttons
+  - Create `Features` component with icon, title, description, and optional link
+  - Action buttons support primary, secondary, and ghost themes
+  - Grid pattern background on feature cards with daisyUI primary color
+  - Auto `target="_blank"` for external URLs in hero actions
+  - Closes FLAME-003
+
+- feat(flame): support lucide + social icons for hero.actions
+  - Action icons resolve from lucide-react first, then fall back to social icon map
+  - Exported `getSocialIcon` from Social.tsx to avoid duplication
+  - Supports GitHub, Twitter, Discord, and other social brand icons
+
+- feat(schema): align schema with docu.json logic and add external link auto-target
+  - Added `additionalProperties: false` to all object definitions for strict validation
+  - Removed unused `heroImage` definition from schema
+  - Removed `target` property from heroAction (now auto-detected)
+  - Updated template/docu.json with home section examples
+
+### Patch Changes
+
+- fix(flame): sanitize SVG pattern ID to remove spaces
+  - Prevents invalid SVG pattern references caused by whitespace in IDs
+
+- fix(flame): use primary color for grid pattern stroke
+  - Grid pattern on feature cards now uses daisyUI primary color variable
+
+- style(flame): add grid pattern background to feature cards
+  - Added decorative SVG grid pattern behind feature card content
+
+- refactor(flame): rename hero fields and add grid pattern to features
+  - Aligned hero field names with docu.json schema
+  - Integrated grid pattern styling into Features component
+
+## 1.0.1
+
+### Patch Changes
+
+- fix(flame): restore role menuitem and hover styling in mobile dropdown menu
+  - Reverted missing `role="menuitem"` attribute on mobile nav dropdown items
+  - Restored hover styling that was lost during refactor
+
+- fix(flame): add progressive padding for nested sidebar items
+  - Add padding-left 1rem for level 1 submenu items
+  - Add padding-left 1rem for level 1 section with children
+  - Change padding-left from pl-4 to pl-2 for level 1 items
+  - Add more padding for level 3 and deeper items
+  - Adjust level 2 padding to pl-4 for proper hierarchy progression
+  - Extract shared `levelPadding` variable to avoid duplication
+
+## 1.0.0
+
+### Major Changes
+
+- First stable release of @docubook/flame
+  - Bun-native documentation framework with React, MDX, and filesystem routing
+  - Lightweight SSR with client hydration for interactive islands
+  - HMR support during development
+  - Static build to pre-render all pages for deployment
+  - 📦 ~57 kB packed, ~207 kB unpacked
+
+### Patch Changes
+
+- fix(flame): improve search indexing, error handling, and mobile navigation
+  - Enhanced search indexer to preserve component text content
+  - Corrected fuzzy search scoring bias for long words
+  - Improved error handling throughout search pipeline
+
+- fix(flame): handle MDX component load error explicitly
+  - Added explicit error handling when MDX components fail to load
+  - Prevents silent failures in the rendering pipeline
+
+- test(flame): add unit and integration tests for search indexer
+  - Added comprehensive test coverage for search functionality
+
+- chore: remove rc tag from docs
+  - Updated documentation to reflect stable release status
+
+## 1.0.0-rc.1
+
+### Patch Changes
+
+- refactor(ui): migrate to flat structure, remove unused APIs, fix dropdown/pagination
+  - Migrated @docubook/ui-react to flat component structure
+  - Removed unused APIs and cleaned up exports
+  - Fixed dropdown and pagination component behavior
+
+- refactor(ui-react): fix cn utility, use client directives, trim pagination
+  - Fixed `cn` utility for proper class merging
+  - Added `"use client"` directives where needed
+  - Streamlined pagination component
+
+- chore(flame): release candidate
+  - Marked as release candidate for 1.0.0 stable
+
+## 1.0.0-beta.80
+
+### Patch Changes
+
+- refactor(flame): split pagination component and improve build performance
+  - Extracted pagination into separate component for better code splitting
+  - Improved build performance through component decomposition
+
+- fix(flame): resolve concurrency bug, deduplicate MDX pipeline, add tests
+  - Fixed race condition in concurrent MDX processing
+  - Deduplicated MDX pipeline to prevent duplicate renders
+  - Added test coverage for pipeline deduplication
+
+- fix(flame): use relative href in fs-scanner to prevent route path duplication
+  - Changed filesystem scanner to use relative paths
+  - Prevents route paths like `/docs/docs/getting-started`
+
+- fix(flame): use createRoot for sidebar/mobile-bar to resolve hydration mismatch
+  - Replaced direct DOM manipulation with React `createRoot` for sidebar and mobile bar
+  - Resolves hydration mismatch errors between server and client
+
+- refactor(flame): code review improvements and security hardening
+  - Security improvements from code review
+  - Hardened input validation and path handling
+
+## 1.0.0-beta.70
+
+### Patch Changes
+
+- fix(flame): resolve sidebar not rendering when routes are empty
+  - Sidebar now renders with auto-generated routes from filesystem when `routes: []`
+  - Previously failed silently when routes array was empty
+
+- fix(flame): codeblock language unsupport mdx and env
+  - Added support for `mdx` and `env` language identifiers in code blocks
+  - Prevents errors when using unsupported language tags
+
+- feat(flame): npm package distribution with CLI, SSR, and DRY refactor
+  - Published as npm package with `flame` CLI binary
+  - Added server-side rendering support
+  - Refactored shared utilities to reduce duplication
+
+- fix(flame): replace IntersectionObserver with scroll-based TOC heading detection
+  - Replaced IntersectionObserver API with scroll event-based heading detection
+  - More reliable table of contents highlighting across browsers
+
+## 1.0.0-beta.60
+
+### Patch Changes
+
+- fix(flame): prevent path doubling in flattenRoutes and getRouteMap
+  - Fixed route generation to prevent duplicate path segments
+  - Ensures routes like `/docs/getting-started` instead of `/docs/docs/getting-started`
+
+- fix(flame): escape frontmatter title and description in build htmlShell
+  - Properly escapes HTML entities in frontmatter fields
+  - Prevents XSS through malformed frontmatter content
+
+- fix(flame): only persist build cache on fully successful build
+  - Build cache is now only saved when all pages build successfully
+  - Prevents corrupted cache from partial build failures
+
+- fix(flame): replace shell template with safe Bun.spawn for tailwind cli
+  - Replaced shell command interpolation with `Bun.spawn` for Tailwind CSS CLI
+  - Eliminates shell injection risk in build pipeline
+
+- fix(flame): refine search indexer to preserve component text content
+  - Search indexer now correctly extracts text from React components
+  - Improves search accuracy for MDX content with embedded components
+
+- fix(flame): correct fuzzy search scoring bias for long words
+  - Fixed scoring algorithm that unfairly penalized longer search terms
+  - More balanced search results across word lengths
+
+- fix(flame): replace unsafe-inline CSP with nonce and hash-based approach
+  - Replaced `unsafe-inline` Content Security Policy with nonce-based approach
+  - Added hash-based CSP for inline scripts
+  - Significant security improvement for production deployments
+
+- fix(flame): prevent path traversal via directory name prefix confusion
+  - Added validation to prevent directory names from being used to traverse paths
+  - Blocks attempts like `../` in directory names
+
+- fix(flame): eliminate duplicate routes for index.mdx in subdirectories
+  - Fixed route generation to not create duplicate entries for index files
+  - Each directory now has exactly one index route
+
+- perf(flame): add optimizeImports for lucide-react barrel optimization
+  - Added import optimization for lucide-react icons
+  - Reduces bundle size by tree-shaking unused icon imports
+
+- fix(flame): resolve timer leak in Toc.tsx handleLinkClick
+  - Fixed memory leak from uncleared timers in table of contents
+  - Timers are now properly cleaned up on component unmount
+
+- fix(flame): resolve MDX hydration mismatch and content flicker
+  - Fixed hydration mismatch between server-rendered and client-rendered MDX
+  - Eliminated content flicker during page load
+
+- refactor(flame): use hydrateRoot + MDXRemote for client hydration
+  - Migrated from vanilla DOM manipulation to React `hydrateRoot`
+  - MDX content now hydrates properly with React's reconciliation
+
+## 1.0.0-beta.50
+
+### Patch Changes
+
+- fix(flame): improve logger data integrity and error observability
+  - Enhanced logger to maintain data integrity during concurrent writes
+  - Added structured error context for better debugging
+
+- fix(flame): address PR #93 review — DRY logger guard, fix version/colors/stderr
+  - DRY'd up logger guard logic
+  - Fixed version display, color handling, and stderr output
+  - Added test coverage for logger improvements
+
+## 1.0.0-beta.40
+
+### Minor Changes
+
+- feat(flame): add optional Sentry error tracking integration
+  - Added pluggable Sentry integration for error tracking
+  - Configurable via `docu.json` configuration
+
+- feat: implement structured logging and observability
+  - Added structured logging with consistent format
+  - Improved observability for build and runtime processes
+
+### Patch Changes
+
+- fix(security): add path traversal validation in preview.ts and strengthen server.ts guard
+  - Added path traversal checks in preview server
+  - Strengthened input validation in dev server
+
+- fix(security): validate slug path before git operations
+  - Slug paths are now validated before any git commands
+  - Prevents command injection through malicious slugs
+
+- feat(security): add HTTP security headers to all applications
+  - Added security headers (CSP, X-Frame-Options, etc.) to all served pages
+  - Protects against clickjacking, MIME sniffing, and other attacks
+
+- fix(packages): path traversal guard, CI-compatible logger, and strict error handling
+  - Added path traversal guards across all packages
+  - Logger now works correctly in CI environments
+  - Strict error handling prevents silent failures
+
+- fix: resolve silent error swallowing in flame build pipeline
+  - Build errors are now properly propagated and reported
+  - Previously errors were caught and silently discarded
+
+- fix: single MDX error kills entire flame build
+  - One failing MDX file no longer crashes the entire build
+  - Build continues with remaining files and reports individual errors
+
+- fix: Replaced useSyncExternalStore with getServerSnapshot
+  - Fixed server-side rendering compatibility
+  - Proper snapshot handling for React 19
+
+- perf: sequential build, hover re-renders, framer-motion bloat
+  - Optimized build to process files sequentially for stability
+  - Reduced unnecessary re-renders on hover interactions
+  - Removed framer-motion dependency to reduce bundle size
+
+- fix(flame): error boundary in flame dev server
+  - Added error boundary to catch and display runtime errors
+  - Dev server no longer crashes on component errors
+
+- fix: issues URL injection, path traversal, innerHTML
+  - Fixed URL injection vulnerabilities
+  - Prevented path traversal in URL handling
+  - Replaced unsafe `innerHTML` with safe alternatives
+
+- chore: remove dead files and fix misclassified deps
+  - Cleaned up unused files
+  - Moved dev-only dependencies to devDependencies
+
+- fix(flame): UI improvements and navbar active state
+  - Improved navbar active state highlighting
+  - General UI polish and consistency fixes
+
+- feat(flame): add mobile bar with hydration and sticky behavior
+  - Added mobile navigation bar component
+  - Sticky positioning with proper hydration support
+
+- fix(flame): fix pagination and route path generation
+  - Fixed pagination component rendering
+  - Corrected route path generation logic

--- a/packages/flame/README.md
+++ b/packages/flame/README.md
@@ -16,7 +16,7 @@
 
 ```bash
 mkdir my-docs && cd my-docs
-bun add @docubook/flame@rc
+bun add @docubook/flame
 bunx flame init
 bun run dev
 ```

--- a/packages/flame/README.md
+++ b/packages/flame/README.md
@@ -65,24 +65,64 @@ bun run deploy    # Build + prepare for GitHub Pages
 
 ## Configuration
 
-`docu.json` controls your site:
+`docu.json` controls your site. Full example:
 
 ```json
 {
+  "$schema": "https://cdn.jsdelivr.net/npm/@docubook/flame/docu.schema.json",
   "meta": {
     "title": "My Docs",
-    "description": "Documentation powered by DocuBook Flame"
+    "description": "Documentation powered by DocuBook Flame",
+    "baseURL": "https://example.com",
+    "favicon": "/docs/assets/images/favicon.ico"
+  },
+  "home": {
+    "hero": {
+      "tagline": "#MyDocs",
+      "headline": "Documentation",
+      "description": "Welcome to your documentation site.",
+      "actions": [
+        { "text": "Get Started", "link": "/docs", "theme": "primary" },
+        { "text": "GitHub", "link": "https://github.com", "theme": "ghost", "icon": "github" }
+      ]
+    },
+    "features": [
+      { "icon": "Zap", "title": "Fast", "description": "Instant builds.", "link": "/docs" }
+    ]
   },
   "navbar": {
+    "logo": { "src": "/docs/assets/logo.svg", "alt": "Logo" },
     "logoText": "My Docs",
     "menu": [
       { "title": "Home", "href": "/" },
       { "title": "Docs", "href": "/docs" }
     ]
   },
+  "footer": {
+    "social": [
+      { "name": "github", "url": "https://github.com/you" }
+    ]
+  },
+  "repo": {
+    "url": "https://github.com/you/repo",
+    "path": "blob/main/{filePath}",
+    "edit": true
+  },
   "routes": []
 }
 ```
+
+### Home Page
+
+The `home` section configures your landing page with a hero section and feature cards:
+
+|      Property      |                             Description                             |
+| ------------------ | ------------------------------------------------------------------- |
+| `hero.tagline`     | Small text above the headline (e.g., product name)                  |
+| `hero.headline`    | **Required.** Main heading text                                     |
+| `hero.description` | Description below the headline                                      |
+| `hero.actions`     | Array of CTA buttons with `text`, `link`, `theme`, `icon`, `target` |
+| `features`         | Array of feature cards with `icon`, `title`, `description`, `link`  |
 
 ### Routes
 
@@ -166,11 +206,11 @@ Reference in MDX:
 
 ## Comparison
 
-| Framework | Runtime | UI | Approach |
-|---|---|---|---|
-| Docusaurus | Node.js | React | Full-featured, plugin-heavy |
-| VitePress | Node.js | Vue | Lightweight, Vue-only |
-| Nextra | Node.js | React | Next.js-based |
+|      Framework      | Runtime |    UI     |          Approach           |
+| ------------------- | ------- | --------- | --------------------------- |
+| Docusaurus          | Node.js | React     | Full-featured, plugin-heavy |
+| VitePress           | Node.js | Vue       | Lightweight, Vue-only       |
+| Nextra              | Node.js | React     | Next.js-based               |
 | **@docubook/flame** | **Bun** | **React** | **Minimal, Bun-native SSR** |
 
 ---

--- a/packages/flame/docu.json
+++ b/packages/flame/docu.json
@@ -8,9 +8,9 @@
   },
   "home": {
     "hero": {
-      "name": "DocuBook",
-      "text": "Flame",
-      "tagline": "A blazing-fast React + MDX framework powered by Bun, built for modern documentation experiences.",
+      "tagline": "DocuBook",
+      "headline": "Flame",
+      "description": "A blazing-fast React + MDX framework powered by Bun, built for modern documentation experiences.",
       "actions": [
         {
           "text": "Get Started",

--- a/packages/flame/docu.json
+++ b/packages/flame/docu.json
@@ -8,13 +8,13 @@
   },
   "home": {
     "hero": {
-      "tagline": "DocuBook",
+      "tagline": "#DocuBook",
       "headline": "Flame",
       "description": "A blazing-fast React + MDX framework powered by Bun, built for modern documentation experiences.",
       "actions": [
         {
           "text": "Get Started",
-          "link": "/docs/getting-started",
+          "link": "/docs/getting-started/introduction",
           "theme": "primary"
         },
         {
@@ -30,7 +30,7 @@
         "icon": "Zap",
         "title": "Lightning Fast",
         "description": "Powered by Bun for instant builds and hot module replacement.",
-        "link": "/docs/getting-started"
+        "link": "/docs"
       },
       {
         "icon": "Paintbrush",

--- a/packages/flame/docu.json
+++ b/packages/flame/docu.json
@@ -21,7 +21,7 @@
           "text": "GitHub",
           "link": "https://github.com/DocuBook/docubook",
           "theme": "ghost",
-          "icon": "ExternalLink"
+          "icon": "github"
         }
       ]
     },

--- a/packages/flame/docu.json
+++ b/packages/flame/docu.json
@@ -6,6 +6,46 @@
     "baseURL": "https://docubook.pro",
     "favicon": "/docs/assets/images/favicon.ico"
   },
+  "home": {
+    "hero": {
+      "name": "DocuBook",
+      "text": "Flame",
+      "tagline": "A blazing-fast React + MDX framework powered by Bun, built for modern documentation experiences.",
+      "actions": [
+        {
+          "text": "Get Started",
+          "link": "/docs/getting-started",
+          "theme": "primary"
+        },
+        {
+          "text": "GitHub",
+          "link": "https://github.com/DocuBook/docubook",
+          "theme": "ghost",
+          "icon": "github"
+        }
+      ]
+    },
+    "features": [
+      {
+        "icon": "Zap",
+        "title": "Lightning Fast",
+        "description": "Powered by Bun for instant builds and hot module replacement.",
+        "link": "/docs/getting-started"
+      },
+      {
+        "icon": "Paintbrush",
+        "title": "Themeable",
+        "description": "Customize with Tailwind CSS and DaisyUI for beautiful documentation.",
+        "link": "/docs/getting-started/themes"
+      },
+      {
+        "icon": "Search",
+        "title": "Full-Text Search",
+        "description": "Built-in search with Algolia integration for easy content discovery.",
+        "link": "/docs/getting-started/search"
+      }
+    ]
+  },
   "navbar": {
     "logo": {
       "src": "/docs/assets/images/docu.svg",

--- a/packages/flame/docu.json
+++ b/packages/flame/docu.json
@@ -98,6 +98,7 @@
         {
           "title": "Search",
           "href": "/search",
+          "noLink": true,
           "items": [
             {
               "title": "Built-in",

--- a/packages/flame/docu.json
+++ b/packages/flame/docu.json
@@ -21,7 +21,7 @@
           "text": "GitHub",
           "link": "https://github.com/DocuBook/docubook",
           "theme": "ghost",
-          "icon": "github"
+          "icon": "Github"
         }
       ]
     },

--- a/packages/flame/docu.json
+++ b/packages/flame/docu.json
@@ -21,7 +21,7 @@
           "text": "GitHub",
           "link": "https://github.com/DocuBook/docubook",
           "theme": "ghost",
-          "icon": "Github"
+          "icon": "ExternalLink"
         }
       ]
     },

--- a/packages/flame/docu.schema.json
+++ b/packages/flame/docu.schema.json
@@ -18,6 +18,18 @@
       },
       "required": ["title"]
     },
+    "home": {
+      "type": "object",
+      "description": "Home page configuration",
+      "properties": {
+        "hero": { "$ref": "#/$defs/hero" },
+        "features": {
+          "type": "array",
+          "description": "Feature cards displayed on home page",
+          "items": { "$ref": "#/$defs/homeFeature" }
+        }
+      }
+    },
     "navbar": {
       "type": "object",
       "description": "Navigation bar configuration",
@@ -125,6 +137,66 @@
         }
       },
       "required": ["title", "href"]
+    },
+    "hero": {
+      "type": "object",
+      "description": "Hero section configuration for home page",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name displayed above the main text (e.g., product name)"
+        },
+        "text": { "type": "string", "description": "Main heading text" },
+        "tagline": {
+          "type": "string",
+          "description": "Subheading text displayed below the main text"
+        },
+        "image": { "$ref": "#/$defs/heroImage" },
+        "actions": {
+          "type": "array",
+          "description": "Action buttons displayed in the hero section",
+          "items": { "$ref": "#/$defs/heroAction" }
+        }
+      },
+      "required": ["text"]
+    },
+    "heroImage": {
+      "type": "object",
+      "description": "Hero section image configuration",
+      "properties": {
+        "src": { "type": "string", "description": "Image source path" },
+        "alt": { "type": "string", "description": "Image alt text" },
+        "light": { "type": "string", "description": "Image path for light theme" },
+        "dark": { "type": "string", "description": "Image path for dark theme" }
+      },
+      "required": ["src"]
+    },
+    "heroAction": {
+      "type": "object",
+      "description": "Action button in hero section",
+      "properties": {
+        "text": { "type": "string", "description": "Button label" },
+        "link": { "type": "string", "description": "Button link URL" },
+        "theme": {
+          "type": "string",
+          "description": "Button color theme",
+          "enum": ["primary", "secondary", "ghost"]
+        },
+        "icon": { "type": "string", "description": "Lucide icon name" },
+        "target": { "type": "string", "description": "Link target attribute" }
+      },
+      "required": ["text", "link"]
+    },
+    "homeFeature": {
+      "type": "object",
+      "description": "Feature card for home page",
+      "properties": {
+        "icon": { "type": "string", "description": "Lucide icon name" },
+        "title": { "type": "string", "description": "Feature title" },
+        "description": { "type": "string", "description": "Feature description" },
+        "link": { "type": "string", "description": "Feature link URL" }
+      },
+      "required": ["title", "description"]
     }
   }
 }

--- a/packages/flame/docu.schema.json
+++ b/packages/flame/docu.schema.json
@@ -10,6 +10,7 @@
     "meta": {
       "type": "object",
       "description": "Site metadata",
+      "additionalProperties": false,
       "properties": {
         "title": { "type": "string", "description": "Site title" },
         "description": { "type": "string", "description": "Site description" },
@@ -21,6 +22,7 @@
     "home": {
       "type": "object",
       "description": "Home page configuration",
+      "additionalProperties": false,
       "properties": {
         "hero": { "$ref": "#/$defs/hero" },
         "features": {
@@ -33,9 +35,11 @@
     "navbar": {
       "type": "object",
       "description": "Navigation bar configuration",
+      "additionalProperties": false,
       "properties": {
         "logo": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "src": { "type": "string", "description": "Logo image path" },
             "alt": { "type": "string", "description": "Logo alt text" }
@@ -47,6 +51,7 @@
           "description": "Top navigation menu items",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "title": { "type": "string" },
               "href": { "type": "string" }
@@ -59,12 +64,14 @@
     "footer": {
       "type": "object",
       "description": "Footer configuration",
+      "additionalProperties": false,
       "properties": {
         "social": {
           "type": "array",
           "description": "Social media links",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "name": {
                 "type": "string",
@@ -96,6 +103,7 @@
     "repo": {
       "type": "object",
       "description": "Repository configuration for edit links",
+      "additionalProperties": false,
       "properties": {
         "url": { "type": "string", "description": "Repository URL" },
         "path": {
@@ -114,6 +122,7 @@
   "$defs": {
     "route": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "title": { "type": "string", "description": "Display title" },
         "href": { "type": "string", "description": "URL path" },
@@ -124,6 +133,7 @@
         "context": {
           "type": "object",
           "description": "Context metadata for sidebar section",
+          "additionalProperties": false,
           "properties": {
             "icon": { "type": "string", "description": "Lucide icon name" },
             "title": { "type": "string", "description": "Context switcher title" },
@@ -141,6 +151,7 @@
     "hero": {
       "type": "object",
       "description": "Hero section configuration for home page",
+      "additionalProperties": false,
       "properties": {
         "tagline": {
           "type": "string",
@@ -151,7 +162,6 @@
           "type": "string",
           "description": "Description text displayed below the headline"
         },
-        "image": { "$ref": "#/$defs/heroImage" },
         "actions": {
           "type": "array",
           "description": "Action buttons displayed in the hero section",
@@ -160,20 +170,10 @@
       },
       "required": ["headline"]
     },
-    "heroImage": {
-      "type": "object",
-      "description": "Hero section image configuration",
-      "properties": {
-        "src": { "type": "string", "description": "Image source path" },
-        "alt": { "type": "string", "description": "Image alt text" },
-        "light": { "type": "string", "description": "Image path for light theme" },
-        "dark": { "type": "string", "description": "Image path for dark theme" }
-      },
-      "required": ["src"]
-    },
     "heroAction": {
       "type": "object",
       "description": "Action button in hero section",
+      "additionalProperties": false,
       "properties": {
         "text": { "type": "string", "description": "Button label" },
         "link": { "type": "string", "description": "Button link URL" },
@@ -182,14 +182,14 @@
           "description": "Button color theme",
           "enum": ["primary", "secondary", "ghost"]
         },
-        "icon": { "type": "string", "description": "Lucide icon name" },
-        "target": { "type": "string", "description": "Link target attribute" }
+        "icon": { "type": "string", "description": "Lucide icon name" }
       },
       "required": ["text", "link"]
     },
     "homeFeature": {
       "type": "object",
       "description": "Feature card for home page",
+      "additionalProperties": false,
       "properties": {
         "icon": { "type": "string", "description": "Lucide icon name" },
         "title": { "type": "string", "description": "Feature title" },

--- a/packages/flame/docu.schema.json
+++ b/packages/flame/docu.schema.json
@@ -142,14 +142,14 @@
       "type": "object",
       "description": "Hero section configuration for home page",
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name displayed above the main text (e.g., product name)"
-        },
-        "text": { "type": "string", "description": "Main heading text" },
         "tagline": {
           "type": "string",
-          "description": "Subheading text displayed below the main text"
+          "description": "Tagline displayed above the headline (e.g., product name)"
+        },
+        "headline": { "type": "string", "description": "Main heading text" },
+        "description": {
+          "type": "string",
+          "description": "Description text displayed below the headline"
         },
         "image": { "$ref": "#/$defs/heroImage" },
         "actions": {
@@ -158,7 +158,7 @@
           "items": { "$ref": "#/$defs/heroAction" }
         }
       },
-      "required": ["text"]
+      "required": ["headline"]
     },
     "heroImage": {
       "type": "object",

--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/flame",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "description": "A blazing-fast React + MDX framework powered by Bun, built for modern documentation experiences.",
   "type": "module",
   "bin": {
@@ -40,7 +40,9 @@
     "static-site",
     "daisyui",
     "bun",
-    "docs framework"
+    "docs framework",
+    "react",
+    "react-dom"
   ],
   "homepage": "https://docubook.pro/",
   "repository": {

--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/flame",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A blazing-fast React + MDX framework powered by Bun, built for modern documentation experiences.",
   "type": "module",
   "bin": {

--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/flame",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A blazing-fast React + MDX framework powered by Bun, built for modern documentation experiences.",
   "type": "module",
   "bin": {

--- a/packages/flame/template/docs/index.mdx
+++ b/packages/flame/template/docs/index.mdx
@@ -132,7 +132,7 @@ docs/
 
 Reference in MDX:
 
-```mdx
+```markdown
 ![Screenshot](/docs/assets/images/screenshot.png)
 ```
 
@@ -183,7 +183,7 @@ Upload the contents of `.docu/dist/` to any static hosting (Netlify, Cloudflare 
 
 Copy `.env.example` to `.env` to customize:
 
-```env
+```
 # Server port (default: 3000)
 PORT=3000
 
@@ -201,7 +201,7 @@ bun add @sentry/bun
 
 Then set environment variables:
 
-```env
+```
 SENTRY_DSN=https://your-dsn@sentry.io/project-id
 ```
 

--- a/packages/flame/template/docs/index.mdx
+++ b/packages/flame/template/docs/index.mdx
@@ -25,7 +25,7 @@ No heavy abstractions. No complex tooling. Just a minimal layer between your con
 
 ```bash
 mkdir my-docs && cd my-docs
-bun add @docubook/flame@rc
+bun add @docubook/flame
 bunx flame init
 bun run dev
 ```

--- a/packages/flame/template/docs/index.mdx
+++ b/packages/flame/template/docs/index.mdx
@@ -1,21 +1,38 @@
 ---
-title: DocuBook Flame
-description: A Bun-native framework for modern documentation experiences.
+title: DocuBook Flame 🔥
+description: Fast as flame — a Bun-native framework for modern documentation experiences.
 date: 2026-05-24
 ---
 
 **@docubook/flame** is a lightweight runtime for building documentation websites using React, MDX, and filesystem-based routing — all running on Bun.
 
+No heavy abstractions. No complex tooling. Just a minimal layer between your content and the browser.
+
+> **Lightweight** — 📦 ~57 kB packed, ~207 kB unpacked. No bloat, just fire.
+
+## Features
+
+- **Bun-native** — instant startup, native TypeScript, fast builds
+- **React-first** — JSX/TSX, hooks, component composition
+- **MDX content** — write Markdown with embedded React components
+- **Filesystem routing** — auto-detect routes from `docs/` folder
+- **Lightweight SSR** — React server-side rendering without a heavy framework
+- **Client hydration** — interactive islands for sidebar, TOC, and MDX components
+- **HMR** — instant reload on docs changes during development
+- **Static build** — pre-render all pages to static HTML for deployment
+
 ## Quick Start
 
 ```bash
 mkdir my-docs && cd my-docs
-bun add @docubook/flame
+bun add @docubook/flame@rc
 bunx flame init
 bun run dev
 ```
 
 ## Project Structure
+
+After `flame init`, your project looks like:
 
 ```
 my-docs/
@@ -24,17 +41,17 @@ my-docs/
 ├── docu.json          # Site configuration (navbar, routes, meta)
 ├── package.json       # Dependencies
 └── .docu/
-    └── dist/          # Build output (after bun run build)
+    └── dist/          # Build output (after `bun run build`)
 ```
 
 ## Commands
 
-|      Command      |           Description            |
-| ----------------- | -------------------------------- |
-| `bun run dev`     | Start dev server with HMR        |
-| `bun run build`   | Static build to `.docu/dist/`    |
-| `bun run preview` | Serve built output locally       |
-| `bun run deploy`  | Build + prepare for GitHub Pages |
+```bash
+bun run dev       # Start dev server with HMR
+bun run build     # Static build to .docu/dist/
+bun run preview   # Serve built output locally
+bun run deploy    # Build + prepare for GitHub Pages
+```
 
 ## Configuration
 
@@ -57,7 +74,34 @@ my-docs/
 }
 ```
 
-When `routes` is empty, navigation is auto-generated from your `docs/` folder structure.
+### Routes
+
+When `routes` is an empty array `[]`, Flame automatically scans your `docs/` folder at build-time and generates the sidebar navigation from the directory structure. Folders become collapsible sections, and `.mdx`/`.md` files become links — sorted alphabetically.
+
+To define navigation manually, populate the `routes` array:
+
+```json
+{
+  "routes": [
+    {
+      "title": "Getting Started",
+      "href": "/getting-started",
+      "noLink": true,
+      "context": {
+        "icon": "BookOpen",
+        "title": "Guides",
+        "description": "Set up your Documentation"
+      },
+      "items": [
+        { "title": "Introduction", "href": "/introduction" },
+        { "title": "Installation", "href": "/installation" }
+      ]
+    }
+  ]
+}
+```
+
+> Manual routes take priority — if `routes` has entries, folder scanning is skipped entirely.
 
 ## Routing
 
@@ -72,6 +116,45 @@ docs/
     └── card.mdx                 → /docs/components/card
 ```
 
+## Assets
+
+Place images and static files in `docs/assets/`. They are copied to the build output and accessible at `/docs/assets/`.
+
+```
+docs/
+├── assets/
+│   └── images/
+│       ├── logo.svg
+│       └── screenshot.png
+└── getting-started/
+    └── introduction.mdx
+```
+
+Reference in MDX:
+
+```mdx
+![Screenshot](/docs/assets/images/screenshot.png)
+```
+
+> The `docs/assets/` directory is excluded from route scanning — files inside it won't appear in the sidebar.
+
+## Architecture
+
+- **Bun** — runtime, bundler, file watcher
+- **React + React DOM** — rendering (SSR + client hydration)
+- **@docubook/core** — MDX compilation, rehype/remark plugins
+- **@docubook/mdx-content** — pre-built MDX components
+- **Tailwind CSS + daisyUI** — styling
+
+## Comparison
+
+|      Framework      | Runtime |    UI     |          Approach           |
+| ------------------- | ------- | --------- | --------------------------- |
+| Docusaurus          | Node.js | React     | Full-featured, plugin-heavy |
+| VitePress           | Node.js | Vue       | Lightweight, Vue-only       |
+| Nextra              | Node.js | React     | Next.js-based               |
+| **@docubook/flame** | **Bun** | **React** | **Minimal, Bun-native SSR** |
+
 ## Deployment
 
 ### GitHub Pages
@@ -80,26 +163,49 @@ docs/
 bun run deploy
 ```
 
-This will run a production build, add `.nojekyll`, and generate `.github/workflows/deploy.yml`.
+This will:
+
+1. Run production build → output to `.docu/dist/`
+2. Add `.nojekyll` file
+3. Generate `.github/workflows/deploy.yml` (first run only)
 
 Then push to GitHub and enable Pages: **Settings → Pages → Source: GitHub Actions**
 
-### Other Hosts
+### Manual / Other Hosts
 
 ```bash
 bun run build
 ```
 
-Upload `.docu/dist/` to any static hosting (Netlify, Cloudflare Pages, Vercel, S3, etc).
+Upload the contents of `.docu/dist/` to any static hosting (Netlify, Cloudflare Pages, Vercel, S3, etc).
 
 ## Environment Variables
 
-Copy `.env.example` to `.env`:
+Copy `.env.example` to `.env` to customize:
+
+```env
+# Server port (default: 3000)
+PORT=3000
+
+# Error Monitoring (optional)
+SENTRY_DSN=https://your-dsn@sentry.io/project-id
+```
+
+## Error Monitoring (Optional)
+
+Flame has built-in [Sentry](https://sentry.io) support for error tracking. To enable:
 
 ```bash
-PORT=3000
-# SENTRY_DSN=https://your-dsn@sentry.io/project-id
+bun add @sentry/bun
 ```
+
+Then set environment variables:
+
+```env
+SENTRY_DSN=https://your-dsn@sentry.io/project-id
+```
+
+Errors during dev server and build will be automatically captured. No configuration needed beyond the DSN.
 
 ## Requirements
 

--- a/packages/flame/template/docu.json
+++ b/packages/flame/template/docu.json
@@ -6,6 +6,46 @@
     "baseURL": "http://localhost:3000",
     "favicon": "/docs/assets/images/favicon.ico"
   },
+  "home": {
+    "hero": {
+      "tagline": "#MyDocs",
+      "headline": "Documentation",
+      "description": "Welcome to your documentation site powered by DocuBook Flame.",
+      "actions": [
+        {
+          "text": "Get Started",
+          "link": "/docs/getting-started/introduction",
+          "theme": "primary"
+        },
+        {
+          "text": "GitHub",
+          "link": "https://github.com/gitfromwildan",
+          "theme": "ghost",
+          "icon": "github"
+        }
+      ]
+    },
+    "features": [
+      {
+        "icon": "Zap",
+        "title": "Lightning Fast",
+        "description": "Powered by Bun for instant builds and hot module replacement.",
+        "link": "/docs"
+      },
+      {
+        "icon": "Paintbrush",
+        "title": "Themeable",
+        "description": "Customize with Tailwind CSS and DaisyUI for beautiful documentation.",
+        "link": "#"
+      },
+      {
+        "icon": "Search",
+        "title": "Full-Text Search",
+        "description": "Built-in search for easy content discovery.",
+        "link": "#"
+      }
+    ]
+  },
   "navbar": {
     "logo": {
       "src": "/docs/assets/images/docu.svg",


### PR DESCRIPTION
### Summary

Fixed search indexing, error handling, and mobile navigation in Flame.

### Changes

- search-indexer.ts: Added stripJsx() to remove JSX components from the search index, only indexing plain text. Skip markdown table rows (| ... |).
- utils.ts: Fixed silent swallow — all catches now log console.error with error context and explicit fallback.
- Sidebar.tsx: Fixed MobileBar dropdown — replace DropdownLink with Anchor + activeWhen to make the active state work in /docs*.
- Anchor.tsx: Removed hardcoded text-blue-600 hover:text-blue-800 from base styles, letting consuming components determine the color via className.
- template/docs/index.mdx: Aligned with README.md — added Features, Routes, Assets, Architecture, Comparison, and Error Monitoring.
- package.json: Updated files include pattern.

### Features Request

feature requests from @dwindiramadhana

- nested levelPadding hierarchy at sidebar
<img width="270" height="542" alt="image" src="https://github.com/user-attachments/assets/33aa1469-7d0c-4ab8-ae4f-e5fe6a67bfc3" />

> [!TIP]
> homepage editable on config hybrid vitepress + docusaurus implementation

<img width="1205" height="955" alt="image" src="https://github.com/user-attachments/assets/5a40ad89-d245-4447-880c-e6a98332ef3d" />

> [!NOTE]
> editable on docu.json

```json
  "home": {
    "hero": {
      "tagline": "#DocuBook",
      "headline": "Flame",
      "description": "A blazing-fast React + MDX framework powered by Bun, built for modern documentation experiences.",
      "actions": [
        {
          "text": "Get Started",
          "link": "/docs/getting-started/introduction",
          "theme": "primary"
        },
        {
          "text": "GitHub",
          "link": "https://github.com/DocuBook/docubook",
          "theme": "ghost",
          "icon": "github"
        }
      ]
    },
    "features": [
      {
        "icon": "Zap",
        "title": "Lightning Fast",
        "description": "Powered by Bun for instant builds and hot module replacement.",
        "link": "/docs"
      },
      {
        "icon": "Paintbrush",
        "title": "Themeable",
        "description": "Customize with Tailwind CSS and DaisyUI for beautiful documentation.",
        "link": "/docs/getting-started/themes"
      },
      {
        "icon": "Search",
        "title": "Full-Text Search",
        "description": "Built-in search with Algolia integration for easy content discovery.",
        "link": "/docs/getting-started/search"
      }
    ]
  },
any config....
```


### Notes

- stripJsx also preserves the inner content ($1) of paired JSX tags, so text inside <Accordion> remains searchable.