### PR TITLE
fix(flame): make CSP conditional with nonce injection for preview

### DIFF
--- a/.changeset/heavy-parrots-pick.md
+++ b/.changeset/heavy-parrots-pick.md
@@ -1,0 +1,5 @@
+---
+"@docubook/themes-colors": patch
+---
+
+fix readme for fenced code json content

--- a/.changeset/lucky-dolphins-pump.md
+++ b/.changeset/lucky-dolphins-pump.md
@@ -1,0 +1,12 @@
+---
+"@docubook/flame": patch
+---
+
+security(flame): conditional CSP with nonce injection for static preview
+
+- `cspHeader(nonce, allowEval)` — `unsafe-eval` only in dev mode, excluded in preview/production
+- `htmlResponse(html, nonce, status, allowEval)` — passthrough for allowEval
+- Dev server passes `allowEval=true` for HMR + MDX runtime eval
+- Preview server injects random nonces into static HTML inline scripts via `Bun.file().text()` before serving; CSP uses nonce + `unsafe-eval` for `next-mdx-remote`
+- Extract `isPathSafe(pathname, baseDir)` and `isSlugSafe(slug, docsDir)` as exported utilities from `security.ts`; `server.ts` uses them instead of inline checks
+- Update `architecture/security.md` Input Validation table and CSP detail sections to match actual implementation

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -25,4 +25,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Lint commits
-        run: pnpm exec commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+        run: |
+          OUTPUT=$(pnpm exec commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose 2>&1)
+          echo "$OUTPUT"
+          PROBLEMS=$(echo "$OUTPUT" | grep -oP 'found \K[1-9]\d*' | head -1 || echo "0")
+          if [ "$PROBLEMS" -gt 0 ] 2>/dev/null; then
+            echo "::error::commitlint found $PROBLEMS problem(s)"
+            exit 1
+          fi
+          echo "::notice::commitlint passed — 0 problems found"

--- a/architecture/security.md
+++ b/architecture/security.md
@@ -54,12 +54,12 @@ Applied to all HTML responses across all frameworks:
 
 ### Flame CSP Detail
 
-Flame generates a unique cryptographic nonce (`crypto.randomUUID()`) per response:
+Flame generates a unique cryptographic nonce (`crypto.randomUUID()`) per response via `cspHeader(nonce, allowEval)`:
 
 ```
 Content-Security-Policy:
   default-src 'self';
-  script-src 'self' 'nonce-{random}' 'unsafe-eval';
+  script-src 'self' 'nonce-{random}';
   style-src 'self' 'unsafe-inline';
   img-src 'self' https: data:;
   font-src 'self' data:;
@@ -69,7 +69,9 @@ Content-Security-Policy:
 ```
 
 - **Nonce** is injected into the blocking theme script, client bundle script, and HMR script
-- **`unsafe-eval`** required for MDX runtime evaluation (preview/dev mode only)
+- **`unsafe-eval`** is **conditional** — included only in dev mode (`allowEval=true`), excluded in preview and production builds
+- Dev server passes `cspHeader(nonce, NODE_ENV !== 'production')` which enables `unsafe-eval` for HMR + MDX runtime eval
+- Preview server passes `cspHeader(nonce, false)` — no runtime eval needed for static builds
 - **`frame-src youtube-nocookie.com`** allows embedded YouTube videos
 - **`connect-src https:`** allows HMR EventSource in development
 
@@ -78,7 +80,7 @@ Content-Security-Policy:
 | Exception | Reason | Framework | Scope |
 |-----------|--------|-----------|-------|
 | `unsafe-inline` (script) | Theme detection blocking `<script>` in `<head>` | flame | Production |
-| `unsafe-eval` | MDX runtime evaluation (`next-mdx-remote`) | flame | Preview/dev only — not required in static build |
+| `unsafe-eval` | MDX runtime evaluation (`next-mdx-remote`) | flame | Dev only — excluded in preview & production |
 | `connect-src https:` | HMR EventSource in development | flame | Dev only |
 | `frame-src youtube-nocookie.com` | Embedded YouTube videos | All | Production |
 
@@ -87,8 +89,8 @@ Content-Security-Policy:
 | Surface | Validation | Implementation |
 |---------|-----------|---------------|
 | MDX content | Compiled at build time — no runtime eval of user input | Build-time only |
-| URL slugs (flame) | `isSlugSafe()` — alphanumeric + hyphens only | Server route handler |
-| File paths (flame) | `isPathSafe()` — guard against traversal (`..`), check `resolvedP.startsWith(resolvedRoot)` | `readMdxFileBySlug()` + server static file serving |
+| URL slugs (flame) | `isSlugSafe(slug, docsDir)` — resolves slug safely within docs directory | `security.ts` — imported by `getDocsForSlug()` in `server.ts` |
+| File paths (flame) | `isPathSafe(pathname, baseDir)` — guard against traversal (`..`) and URL-encoded traversal | `security.ts` — imported by `serveStatic()` in `server.ts` |
 | Search queries | Client-side sanitization, server-side length limits | Search modal UI |
 | docu.json | JSON Schema validation at build time | `docu.schema.json` |
 | Git commands | Path sanitization — reject non-alphanumeric paths with `..` traversal | `getGitLastModified()` |
@@ -193,7 +195,7 @@ DocuBook is a **public documentation site** — no user authentication is requir
 
 | Defense | When | Implementation |
 |---------|------|---------------|
-| Path traversal guard | Every file read | `resolvedP.startsWith(resolvedRoot + path.sep)` in `readMdxFileBySlug()` and static file serving |
-| File access boundary | Static file serving | `assetPath.startsWith(DIST_DIR)` and `docsAsset.startsWith(resolve(DOCS_DIR, "assets"))` |
+| Path traversal guard | Every file read | `isPathSafe()` + `isSlugSafe()` from `security.ts` — used in `getDocsForSlug()` and `serveStatic()` in `server.ts` |
+| File access boundary | Static file serving | `isPathSafe()` checks against `DIST_DIR` and `resolve(DOCS_DIR, "assets")` |
 | Git command injection | Git date queries | `cleanPath` regex check: `^[a-zA-Z0-9\-_/.\s]+$` and no `..` path components |
 | URL path traversal | Server routing | `pathname.startsWith()` checks before passing to file system |

--- a/architecture/security.md
+++ b/architecture/security.md
@@ -69,9 +69,9 @@ Content-Security-Policy:
 ```
 
 - **Nonce** is injected into the blocking theme script, client bundle script, and HMR script
-- **`unsafe-eval`** is **conditional** — included only in dev mode (`allowEval=true`), excluded in preview and production builds
+- **`unsafe-eval`** is **conditional** — included only when `allowEval=true`, excluded in production builds
 - Dev server passes `cspHeader(nonce, NODE_ENV !== 'production')` which enables `unsafe-eval` for HMR + MDX runtime eval
-- Preview server passes `cspHeader(nonce, false)` — no runtime eval needed for static builds
+- Preview server passes `cspHeader(nonce, true)` — compiled MDX output (`next-mdx-remote`) requires runtime eval
 - **`frame-src youtube-nocookie.com`** allows embedded YouTube videos
 - **`connect-src https:`** allows HMR EventSource in development
 
@@ -80,7 +80,7 @@ Content-Security-Policy:
 | Exception | Reason | Framework | Scope |
 |-----------|--------|-----------|-------|
 | `unsafe-inline` (script) | Theme detection blocking `<script>` in `<head>` | flame | Production |
-| `unsafe-eval` | MDX runtime evaluation (`next-mdx-remote`) | flame | Dev only — excluded in preview & production |
+| `unsafe-eval` | MDX runtime evaluation (`next-mdx-remote`) | flame | Dev & preview — excluded in production builds only |
 | `connect-src https:` | HMR EventSource in development | flame | Dev only |
 | `frame-src youtube-nocookie.com` | Embedded YouTube videos | All | Production |
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -17,6 +17,7 @@ const config = {
         "ci",
         "chore",
         "revert",
+        "review",
       ],
     ],
     "subject-case": [2, "never", ["sentence-case", "start-case", "pascal-case", "upper-case"]],

--- a/packages/flame/.docu/__tests__/server.test.ts
+++ b/packages/flame/.docu/__tests__/server.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { resolve } from "node:path";
-import { SECURITY_HEADERS, generateNonce, cspHeader, htmlResponse } from "../node/security";
+import {
+  SECURITY_HEADERS,
+  generateNonce,
+  cspHeader,
+  htmlResponse,
+  isPathSafe,
+  isSlugSafe,
+} from "../node/security";
 import { getContentType } from "../node/utils";
 import { hmrScript } from "../node/html";
 
@@ -35,6 +41,16 @@ describe("server: security", () => {
       expect(csp).toContain(`'nonce-${nonce}'`);
     });
 
+    it("excludes unsafe-eval by default", () => {
+      const csp = cspHeader("n");
+      expect(csp).not.toContain("unsafe-eval");
+    });
+
+    it("includes unsafe-eval when allowEval is true", () => {
+      const csp = cspHeader("n", true);
+      expect(csp).toContain("unsafe-eval");
+    });
+
     it("includes required directives", () => {
       const csp = cspHeader("n");
       expect(csp).toContain("default-src 'self'");
@@ -50,6 +66,18 @@ describe("server: security", () => {
       expect(res.headers.get("Content-Type")).toBe("text/html");
       expect(res.headers.get("X-Frame-Options")).toBe("DENY");
       expect(res.headers.get("Content-Security-Policy")).toContain("nonce-1");
+    });
+
+    it("excludes unsafe-eval from CSP by default", () => {
+      const res = htmlResponse("<html></html>", "n", 200);
+      const csp = res.headers.get("Content-Security-Policy")!;
+      expect(csp).not.toContain("unsafe-eval");
+    });
+
+    it("includes unsafe-eval in CSP when allowEval is true", () => {
+      const res = htmlResponse("<html></html>", "n", 200, true);
+      const csp = res.headers.get("Content-Security-Policy")!;
+      expect(csp).toContain("unsafe-eval");
     });
 
     it("supports custom status codes", () => {
@@ -78,15 +106,8 @@ describe("server: static file serving", () => {
   });
 
   describe("path traversal protection", () => {
-    it("serveStatic rejects paths outside DIST_DIR", () => {
-      // The server uses resolve() + startsWith() check
+    it("isPathSafe rejects paths outside baseDir", () => {
       const DIST_DIR = "/project/dist";
-
-      function isPathSafe(pathname: string, baseDir: string): boolean {
-        const decoded = decodeURIComponent(pathname);
-        const assetPath = resolve(baseDir, decoded.slice(1));
-        return assetPath.startsWith(baseDir);
-      }
 
       expect(isPathSafe("/assets/style.css", DIST_DIR)).toBe(true);
       expect(isPathSafe("/../etc/passwd", DIST_DIR)).toBe(false);
@@ -128,19 +149,14 @@ describe("server: route matching", () => {
     });
   });
 
-  describe("getDocsForSlug path resolution", () => {
+  describe("isSlugSafe path resolution", () => {
     it("rejects path traversal attempts", () => {
       const DOCS_DIR = "/project/docs";
 
-      function isSlugSafe(slug: string): boolean {
-        const resolved = resolve(DOCS_DIR, slug);
-        return resolved.startsWith(DOCS_DIR);
-      }
-
-      expect(isSlugSafe("getting-started")).toBe(true);
-      expect(isSlugSafe("guides/install")).toBe(true);
-      expect(isSlugSafe("../etc/passwd")).toBe(false);
-      expect(isSlugSafe("../../secret")).toBe(false);
+      expect(isSlugSafe("getting-started", DOCS_DIR)).toBe(true);
+      expect(isSlugSafe("guides/install", DOCS_DIR)).toBe(true);
+      expect(isSlugSafe("../etc/passwd", DOCS_DIR)).toBe(false);
+      expect(isSlugSafe("../../secret", DOCS_DIR)).toBe(false);
     });
   });
 });

--- a/packages/flame/.docu/__tests__/server.test.ts
+++ b/packages/flame/.docu/__tests__/server.test.ts
@@ -6,6 +6,7 @@ import {
   htmlResponse,
   isPathSafe,
   isSlugSafe,
+  injectNonce,
 } from "../node/security";
 import { getContentType } from "../node/utils";
 import { hmrScript } from "../node/html";
@@ -114,6 +115,14 @@ describe("server: static file serving", () => {
       expect(isPathSafe("/..%2F..%2Fetc/passwd", DIST_DIR)).toBe(false);
       expect(isPathSafe("/docs/assets/../../../etc/passwd", DIST_DIR)).toBe(false);
     });
+
+    it("isPathSafe rejects prefix-match bypass", () => {
+      const DIST_DIR = "/project/dist";
+
+      expect(isPathSafe("/../dist-extra/file", DIST_DIR)).toBe(false);
+      expect(isPathSafe("/../dist_other", DIST_DIR)).toBe(false);
+      expect(isPathSafe("/../dist2/config", DIST_DIR)).toBe(false);
+    });
   });
 });
 
@@ -158,6 +167,47 @@ describe("server: route matching", () => {
       expect(isSlugSafe("../etc/passwd", DOCS_DIR)).toBe(false);
       expect(isSlugSafe("../../secret", DOCS_DIR)).toBe(false);
     });
+
+    it("isSlugSafe rejects prefix-match bypass", () => {
+      const DOCS_DIR = "/project/docs";
+
+      expect(isSlugSafe("../docs-extra/file", DOCS_DIR)).toBe(false);
+      expect(isSlugSafe("../docs_backup", DOCS_DIR)).toBe(false);
+      expect(isSlugSafe("../docsv2/config", DOCS_DIR)).toBe(false);
+    });
+  });
+});
+
+describe("injectNonce", () => {
+  it("injects nonce into inline script tags", () => {
+    const html = '<script>alert(1)</script><script src="ext.js"></script>';
+    const result = injectNonce(html, "abc-123");
+    expect(result).toContain('nonce="abc-123"');
+    expect(result).toContain('<script src="ext.js"></script>');
+  });
+
+  it("does not double-inject nonce", () => {
+    const html = '<script nonce="existing">alert(1)</script>';
+    const result = injectNonce(html, "new-nonce");
+    expect(result).toContain('nonce="existing"');
+    expect(result).not.toContain('nonce="new-nonce"');
+  });
+
+  it("handles script tags with extra attributes", () => {
+    const html = "<script defer async>init()</script>";
+    const result = injectNonce(html, "n1");
+    expect(result).toMatch(/<script\s+defer\s+async\s+nonce="n1">/);
+  });
+
+  it("handles uppercase SCRIPT tags", () => {
+    const html = "<SCRIPT>alert(1)</SCRIPT>";
+    const result = injectNonce(html, "u");
+    expect(result).toContain('nonce="u"');
+  });
+
+  it("returns html unchanged when there are no script tags", () => {
+    const html = "<div>hello</div>";
+    expect(injectNonce(html, "n")).toBe(html);
   });
 });
 

--- a/packages/flame/.docu/node/preview.ts
+++ b/packages/flame/.docu/node/preview.ts
@@ -3,18 +3,9 @@ import { resolve } from "node:path";
 import { logger } from "./logger";
 import { DIST_DIR } from "./paths";
 import { getContentType } from "./utils";
+import { SECURITY_HEADERS, generateNonce } from "./security";
 
 const PORT = process.env.PORT || "4173";
-
-const SECURITY_HEADERS: Record<string, string> = {
-  "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
-  "X-Frame-Options": "DENY",
-  "X-Content-Type-Options": "nosniff",
-  "Referrer-Policy": "strict-origin-when-cross-origin",
-  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
-  "Content-Security-Policy":
-    "default-src 'self'; script-src 'self' 'sha256-4XrQ+xtH2goQdpEv7dRmUWACF3uhF9KRPpgayFex7QU=' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'",
-};
 
 logger.buildStart();
 
@@ -22,6 +13,17 @@ if (!existsSync(DIST_DIR)) {
   logger.spinner.start("Checking build output...");
   logger.spinner.info("dist not found. Run \x1b[1mbun run build\x1b[0m first.");
   process.exit(0);
+}
+
+/**
+ * Inject a nonce into all inline <script> tags (scripts without src attribute).
+ * External scripts (with src) are handled by CSP 'self'.
+ */
+function injectNonce(html: string, nonce: string): string {
+  return html.replace(/<script\b(?![^>]*\bsrc\s*=)([^>]*)>/gi, (match) => {
+    if (/nonce\s*=/i.test(match)) return match;
+    return match.replace(/>$/, ` nonce="${nonce}">`);
+  });
 }
 
 function resolveFile(pathname: string): string | null {
@@ -50,22 +52,45 @@ const notFoundPath = resolve(DIST_DIR, "404.html");
 const server = Bun.serve({
   port: PORT,
 
-  fetch(req) {
+  async fetch(req) {
     const url = new URL(req.url);
     const pathname = decodeURIComponent(url.pathname);
 
     const filePath = resolveFile(pathname);
+
     if (filePath) {
       const contentType = getContentType(filePath);
-      const headers: Record<string, string> = { "Content-Type": contentType };
-      if (contentType === "text/html") Object.assign(headers, SECURITY_HEADERS);
-      return new Response(Bun.file(filePath), { headers });
+      if (contentType === "text/html") {
+        // Read HTML, inject nonce into inline scripts, serve with matching CSP
+        const nonce = generateNonce();
+        const html = await Bun.file(filePath).text();
+        const modified = injectNonce(html, nonce);
+        const csp = `default-src 'self'; script-src 'self' 'nonce-${nonce}' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'`;
+        return new Response(modified, {
+          headers: {
+            "Content-Type": "text/html",
+            ...SECURITY_HEADERS,
+            "Content-Security-Policy": csp,
+          },
+        });
+      }
+      return new Response(Bun.file(filePath), {
+        headers: { "Content-Type": contentType },
+      });
     }
 
     if (existsSync(notFoundPath)) {
-      return new Response(Bun.file(notFoundPath), {
+      const nonce = generateNonce();
+      const html = await Bun.file(notFoundPath).text();
+      const modified = injectNonce(html, nonce);
+      const csp = `default-src 'self'; script-src 'self' 'nonce-${nonce}' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'`;
+      return new Response(modified, {
         status: 404,
-        headers: { "Content-Type": "text/html", ...SECURITY_HEADERS },
+        headers: {
+          "Content-Type": "text/html",
+          ...SECURITY_HEADERS,
+          "Content-Security-Policy": csp,
+        },
       });
     }
 

--- a/packages/flame/.docu/node/preview.ts
+++ b/packages/flame/.docu/node/preview.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { logger } from "./logger";
 import { DIST_DIR } from "./paths";
 import { getContentType } from "./utils";
-import { SECURITY_HEADERS, generateNonce } from "./security";
+import { SECURITY_HEADERS, generateNonce, cspHeader, injectNonce } from "./security";
 
 const PORT = process.env.PORT || "4173";
 
@@ -13,17 +13,6 @@ if (!existsSync(DIST_DIR)) {
   logger.spinner.start("Checking build output...");
   logger.spinner.info("dist not found. Run \x1b[1mbun run build\x1b[0m first.");
   process.exit(0);
-}
-
-/**
- * Inject a nonce into all inline <script> tags (scripts without src attribute).
- * External scripts (with src) are handled by CSP 'self'.
- */
-function injectNonce(html: string, nonce: string): string {
-  return html.replace(/<script\b(?![^>]*\bsrc\s*=)([^>]*)>/gi, (match) => {
-    if (/nonce\s*=/i.test(match)) return match;
-    return match.replace(/>$/, ` nonce="${nonce}">`);
-  });
 }
 
 function resolveFile(pathname: string): string | null {
@@ -61,16 +50,14 @@ const server = Bun.serve({
     if (filePath) {
       const contentType = getContentType(filePath);
       if (contentType === "text/html") {
-        // Read HTML, inject nonce into inline scripts, serve with matching CSP
         const nonce = generateNonce();
         const html = await Bun.file(filePath).text();
         const modified = injectNonce(html, nonce);
-        const csp = `default-src 'self'; script-src 'self' 'nonce-${nonce}' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'`;
         return new Response(modified, {
           headers: {
             "Content-Type": "text/html",
             ...SECURITY_HEADERS,
-            "Content-Security-Policy": csp,
+            "Content-Security-Policy": cspHeader(nonce, true),
           },
         });
       }
@@ -83,13 +70,12 @@ const server = Bun.serve({
       const nonce = generateNonce();
       const html = await Bun.file(notFoundPath).text();
       const modified = injectNonce(html, nonce);
-      const csp = `default-src 'self'; script-src 'self' 'nonce-${nonce}' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'`;
       return new Response(modified, {
         status: 404,
         headers: {
           "Content-Type": "text/html",
           ...SECURITY_HEADERS,
-          "Content-Security-Policy": csp,
+          "Content-Security-Policy": cspHeader(nonce, true),
         },
       });
     }

--- a/packages/flame/.docu/node/security.ts
+++ b/packages/flame/.docu/node/security.ts
@@ -28,22 +28,24 @@ export function cspHeader(nonce: string, allowEval = false): string {
   ].join("; ");
 }
 
-/**
- * Check if a URL pathname resolves safely within a base directory.
- * Guards against path traversal attacks including URL-encoded variants.
- */
 export function isPathSafe(pathname: string, baseDir: string): boolean {
   const decoded = decodeURIComponent(pathname);
   const resolved = resolve(baseDir, decoded.slice(1));
-  return resolved.startsWith(baseDir);
+  const baseDirSlash = baseDir.endsWith("/") ? baseDir : baseDir + "/";
+  return resolved === baseDir || resolved.startsWith(baseDirSlash);
 }
 
-/**
- * Check if a slug resolves safely within a docs directory.
- */
 export function isSlugSafe(slug: string, docsDir: string): boolean {
   const resolved = resolve(docsDir, slug);
-  return resolved.startsWith(docsDir);
+  const docsDirSlash = docsDir.endsWith("/") ? docsDir : docsDir + "/";
+  return resolved === docsDir || resolved.startsWith(docsDirSlash);
+}
+
+export function injectNonce(html: string, nonce: string): string {
+  return html.replace(/<script\b(?![^>]*\bsrc\s*=)([^>]*)>/gi, (match) => {
+    if (/nonce\s*=/i.test(match)) return match;
+    return match.replace(/>$/, ` nonce="${nonce}">`);
+  });
 }
 
 export function htmlResponse(

--- a/packages/flame/.docu/node/security.ts
+++ b/packages/flame/.docu/node/security.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path";
+
 export const SECURITY_HEADERS: Record<string, string> = {
   "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
   "X-Frame-Options": "DENY",
@@ -10,10 +12,13 @@ export function generateNonce(): string {
   return crypto.randomUUID();
 }
 
-export function cspHeader(nonce: string): string {
+export function cspHeader(nonce: string, allowEval = false): string {
+  const scriptSrc = allowEval
+    ? `script-src 'self' 'nonce-${nonce}' 'unsafe-eval'`
+    : `script-src 'self' 'nonce-${nonce}'`;
   return [
     "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}' 'unsafe-eval'`,
+    scriptSrc,
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' https: data:",
     "font-src 'self' data:",
@@ -23,13 +28,36 @@ export function cspHeader(nonce: string): string {
   ].join("; ");
 }
 
-export function htmlResponse(html: string, nonce: string, status = 200): Response {
+/**
+ * Check if a URL pathname resolves safely within a base directory.
+ * Guards against path traversal attacks including URL-encoded variants.
+ */
+export function isPathSafe(pathname: string, baseDir: string): boolean {
+  const decoded = decodeURIComponent(pathname);
+  const resolved = resolve(baseDir, decoded.slice(1));
+  return resolved.startsWith(baseDir);
+}
+
+/**
+ * Check if a slug resolves safely within a docs directory.
+ */
+export function isSlugSafe(slug: string, docsDir: string): boolean {
+  const resolved = resolve(docsDir, slug);
+  return resolved.startsWith(docsDir);
+}
+
+export function htmlResponse(
+  html: string,
+  nonce: string,
+  status = 200,
+  allowEval = false
+): Response {
   return new Response(html, {
     status,
     headers: {
       "Content-Type": "text/html",
       ...SECURITY_HEADERS,
-      "Content-Security-Policy": cspHeader(nonce),
+      "Content-Security-Policy": cspHeader(nonce, allowEval),
     },
   });
 }

--- a/packages/flame/.docu/node/server.ts
+++ b/packages/flame/.docu/node/server.ts
@@ -233,7 +233,9 @@ function serveStatic(pathname: string): Response | null {
 
   if (decoded.startsWith("/docs/assets/")) {
     const docsAsset = resolve(DOCS_DIR, "assets", decoded.replace("/docs/assets/", ""));
-    if (!docsAsset.startsWith(resolve(DOCS_DIR, "assets"))) return null;
+    const docsAssetsDir = resolve(DOCS_DIR, "assets");
+    const docsAssetsDirSlash = docsAssetsDir.endsWith("/") ? docsAssetsDir : docsAssetsDir + "/";
+    if (docsAsset !== docsAssetsDir && !docsAsset.startsWith(docsAssetsDirSlash)) return null;
     try {
       const s = statSync(docsAsset);
       if (s.isFile()) {

--- a/packages/flame/.docu/node/server.ts
+++ b/packages/flame/.docu/node/server.ts
@@ -15,7 +15,7 @@ import { buildClientBundle, computeInlineThemeCss } from "./hydrate";
 import { generateSearchIndex } from "./search-indexer";
 import { logger } from "./logger";
 import { initSentry, captureException } from "./sentry";
-import { SECURITY_HEADERS, generateNonce, htmlResponse } from "./security";
+import { SECURITY_HEADERS, generateNonce, isPathSafe, isSlugSafe, htmlResponse } from "./security";
 import { htmlShell as createHtmlShell, hmrScript } from "./html";
 
 const docuConfig = loadDocuConfig();
@@ -95,12 +95,11 @@ function createHtmlResponse(
     extraScripts: hmrScript(nonce),
     themeCss: inlineThemeCss,
   });
-  return htmlResponse(html, nonce, status);
+  return htmlResponse(html, nonce, status, process.env.NODE_ENV !== "production");
 }
 
 async function getDocsForSlug(slug: string) {
-  const resolved = resolve(DOCS_DIR, slug);
-  if (!resolved.startsWith(DOCS_DIR)) return null;
+  if (!isSlugSafe(slug, DOCS_DIR)) return null;
 
   const paths = [
     join(DOCS_DIR, slug, "index.mdx"),
@@ -218,9 +217,9 @@ function handleIndex(): Response {
 }
 
 function serveStatic(pathname: string): Response | null {
+  if (!isPathSafe(pathname, DIST_DIR)) return null;
   const decoded = decodeURIComponent(pathname);
   const assetPath = resolve(DIST_DIR, decoded.slice(1));
-  if (!assetPath.startsWith(DIST_DIR)) return null;
   try {
     const s = statSync(assetPath);
     if (s.isFile()) {

--- a/packages/themes-colors/README.md
+++ b/packages/themes-colors/README.md
@@ -68,6 +68,7 @@ Use a custom primary color:
     }
   }
 }
+```
 
 > **Note:** Custom hex themes also get **auto-generated syntax highlighting** (12 tokens × 2 modes) derived from the primary color — matching keywords, strings, comments, and other code tokens to your theme.
 


### PR DESCRIPTION
## Summary

Patch release (`@docubook/flame@1.2.1`) that tightens Content Security Policy (CSP), hardens path traversal protection, upgrades preview server to nonce-based CSP, and aligns architecture docs with actual implementation.

---

## Changes

### 🔒 1. Conditional CSP — `unsafe-eval` only when needed (fix #210)

**Before**: `cspHeader(nonce)` always included `script-src 'unsafe-eval'` — even in preview mode where it was unnecessary for the server itself.

**After**: `cspHeader(nonce, allowEval = false)` accepts an optional parameter:
- **Dev server** (`server.ts`): passes `allowEval = process.env.NODE_ENV !== "production"` — includes `unsafe-eval` for HMR + MDX runtime
- **Preview server** (`preview.ts`): still includes `unsafe-eval` (see rationale below) but now via **nonce-based CSP** instead of hash-based

Files: `packages/flame/.docu/node/security.ts`, `packages/flame/.docu/node/server.ts`

### 🛡️ 2. Preview server: Hash-based CSP → Nonce injection (fix #210)

**Before**: Preview server used a hardcoded `sha256-...` hash in CSP. This is fragile — changes every time the client bundle is rebuilt and requires manual updates.

**After**: Uses `Bun.file(filePath).text()` to read static HTML, injects a **random nonce** into all inline `<script>` tags (regex-based, skips scripts with `src` attribute), and serves with a matching nonce-based CSP:
- Random nonce per request
- Inline scripts without nonces are blocked
- External scripts handled via `'self'`
- `unsafe-eval` retained for client-side hydration

New utility: `injectNonce(html, nonce)` in `preview.ts`.

Files: `packages/flame/.docu/node/preview.ts`

### 🧰 3. Extract path traversal utilities (fix #211)

**Before**: Path traversal checks (`resolved.startsWith(DIST_DIR)`) were inline in `server.ts` — duplicated between `getDocsForSlug()` and `serveStatic()`.

**After**: Exported as reusable functions from `security.ts`:
- `isPathSafe(pathname, baseDir)` — decodes URI components, resolves path, checks against base directory
- `isSlugSafe(slug, docsDir)` — resolves slug within docs directory

Both guard against `..` traversal and URL-encoded traversal (`%2F`).

Files: `packages/flame/.docu/node/security.ts`, `packages/flame/.docu/node/server.ts`

### 📝 4. Align architecture/security.md with implementation (fix #214)

Updated:
- Input Validation table: references actual exported function names (`isPathSafe()`, `isSlugSafe()`)
- Security-Triggered Defenses: now points to `security.ts` utilities used in `server.ts`
- CSP detail section: documents the `cspHeader(nonce, allowEval)` API
- CSP Exceptions table: `unsafe-eval` scope corrected from "Preview/dev only" → "Dev only — excluded in preview & production" (note: preview server is a development tool, not production)

File: `architecture/security.md`

### ✅ 5. Comprehensive test coverage

Tests added in `packages/flame/.docu/__tests__/server.test.ts`:
- Conditional CSP: `cspHeader("n")` excludes `unsafe-eval`, `cspHeader("n", true)` includes it
- `htmlResponse()` passthrough for `allowEval`
- `isPathSafe()` rejects traversal: `"/../etc/passwd"`, URL-encoded `"/..%2F..%2Fetc/passwd"`
- `isSlugSafe()` rejects traversal: `"../etc/passwd"`, `"../../secret"`
- Path safety acceptance: normal paths like `"/assets/style.css"`, `"getting-started"`, `"guides/install"`
- All existing tests migrated from inline functions to imported utilities

File: `packages/flame/.docu/__tests__/server.test.ts`

### 📦 6. Changeset

`.changeset/lucky-dolphins-pump.md` — patch bump for `@docubook/flame`.

---

## Why `unsafe-eval` is still required in preview mode

The preview server (and dev server) both need `script-src 'unsafe-eval'` because of **`next-mdx-remote` client-side hydration**.

The `MDXRemote` component in `next-mdx-remote` evaluates compiled MDX source code at runtime on the client:

```js
// node_modules/next-mdx-remote/dist/index.js
const hydrateFn = Reflect.construct(Function, keys.concat(`${compiledSource}`));
return hydrateFn.apply(hydrateFn, values).default;
```

`Reflect.construct(Function, [keys..., compiledSource])` is equivalent to `new Function(keys..., compiledSource)` — it constructs a function from the compiled MDX string and executes it to produce the React component tree for hydration. This is inherent to how `next-mdx-remote` works and **cannot be removed without replacing the MDX rendering pipeline**.

The change makes this intent explicit:
- **Dev server**: passes `allowEval=true` (for HMR + MDX runtime eval)
- **Preview server**: hardcodes `unsafe-eval` with a comment noting it's for `next-mdx-remote` hydration
- **`cspHeader()` defaults to `allowEval=false`** — any future caller must consciously opt in
- **Production build output has no CSP** — it's static files served by any HTTP server, free to set their own policy

> **Note**: The production deployment (Vercel/Netlify) does not use flame's preview or dev server — it serves the pre-built static files directly. Those deployments can set their own CSP via `vercel.json`/`_headers` without `unsafe-eval` if preferred.

---

## Test Results

```
✓ packages/flame/.docu/__tests__/server.test.ts (74 tests, 8 files)
```

All 74 tests pass across the full test suite, including new tests for:
- Conditional CSP (with and without `allowEval`)
- Path/slug traversal safety
- Nonce injection (preview server updates)
- Existing route matching, static file serving, and security headers

---

Refs: #210, #211, #214