### PR TITLE
feat(flame): add plugin system with 10 lifecycle hooks

### DIFF
--- a/.changeset/goofy-shoes-occur.md
+++ b/.changeset/goofy-shoes-occur.md
@@ -1,0 +1,11 @@
+---
+"@docubook/flame": minor
+---
+
+Plugin system — 10 hooks, Bun `setup(build)` convention.
+
+- **New**: `plugin.ts` (types), `plugin-loader.ts` (resolve & load), `plugin-builder.ts` (10 registration + 10 execution methods)
+- **Modified**: `build.ts` (pipeline wiring: onStart → onLoad → transformFrontmatter → injectHead/Body → transformHtml → onEnd), `server.ts` (handleRequest), `html.ts` (head/body injection), `mdx.ts` (remark/rehype merge), `types.ts`, `docu.schema.json`
+- **75 tests**: unit (39), integration (8), loader (16), mdx (6), schema (6) — zero regression
+
+No-op when `plugins` is empty. Errors: fail-fast for build hooks, error-isolated for dev server.

--- a/packages/flame/.docu/__tests__/fixtures/factory-plugin.ts
+++ b/packages/flame/.docu/__tests__/fixtures/factory-plugin.ts
@@ -1,0 +1,10 @@
+import type { PluginBuilder, DocuBookPlugin } from "../../node/plugin";
+
+export default function createPlugin(options?: Record<string, unknown>): DocuBookPlugin {
+  return {
+    name: (options?.name as string) || "fixture-factory",
+    setup(_build: PluginBuilder) {
+      // no-op
+    },
+  };
+}

--- a/packages/flame/.docu/__tests__/fixtures/invalid-string.ts
+++ b/packages/flame/.docu/__tests__/fixtures/invalid-string.ts
@@ -1,0 +1,3 @@
+// Export a string instead of a plugin object/function
+const notAPlugin = "this is not a valid plugin";
+export default notAPlugin;

--- a/packages/flame/.docu/__tests__/fixtures/missing-name.ts
+++ b/packages/flame/.docu/__tests__/fixtures/missing-name.ts
@@ -1,0 +1,8 @@
+const plugin = {
+  // Intentionally missing 'name' property
+  setup(_build: unknown) {
+    // no-op
+  },
+};
+
+export default plugin;

--- a/packages/flame/.docu/__tests__/fixtures/missing-setup.ts
+++ b/packages/flame/.docu/__tests__/fixtures/missing-setup.ts
@@ -1,0 +1,6 @@
+const plugin = {
+  name: "missing-setup",
+  // Intentionally missing 'setup' function
+};
+
+export default plugin;

--- a/packages/flame/.docu/__tests__/fixtures/simple-plugin.ts
+++ b/packages/flame/.docu/__tests__/fixtures/simple-plugin.ts
@@ -1,0 +1,10 @@
+import type { PluginBuilder } from "../../node/plugin";
+
+const plugin = {
+  name: "fixture-simple",
+  setup(_build: PluginBuilder) {
+    // no-op
+  },
+};
+
+export default plugin;

--- a/packages/flame/.docu/__tests__/helpers.ts
+++ b/packages/flame/.docu/__tests__/helpers.ts
@@ -1,0 +1,190 @@
+/**
+ * Shared test helpers for plugin system tests.
+ * Extracted to keep tests DRY — avoid duplicating config builders
+ * and boilerplate across plugin.test.ts, plugin-integration.test.ts,
+ * and plugin-loader.test.ts.
+ */
+import { BuildPluginBuilder } from "../node/plugin-builder";
+import type { DocuBookPlugin } from "../node/plugin";
+import type { HtmlShellOptions } from "../node/html";
+
+// ─── Minimal DocuConfig ─────────────────────────────────
+
+export interface TestDocuConfig {
+  meta: { title: string; description: string; baseURL: string };
+  navbar: { logoText: string; menu: never[] };
+  footer: { social: never[] };
+  repo: { url: string; path: string; edit: boolean };
+  routes: never[];
+  plugins: { name: string }[];
+  [key: string]: unknown;
+}
+
+/**
+ * Create a minimal DocuConfig for testing.
+ * @param pluginNames - Optional plugin specifiers to include (default empty).
+ */
+export function createMinimalConfig(pluginNames: string[] = []): TestDocuConfig {
+  return {
+    meta: { title: "Test", description: "Test", baseURL: "https://test.dev" },
+    navbar: { logoText: "Test", menu: [] },
+    footer: { social: [] },
+    repo: { url: "", path: "", edit: false },
+    routes: [],
+    plugins: pluginNames.map((name) => ({ name })),
+  };
+}
+
+// ─── BuildPluginBuilder factory ─────────────────────────
+
+export function createBuilder(pluginNames: string[] = []): BuildPluginBuilder {
+  return new BuildPluginBuilder(createMinimalConfig(pluginNames) as any);
+}
+
+// ─── Default htmlShell options (avoids repeating favicon/css/js 4×) ──
+
+export const BASE_HTML_OPTS: Pick<
+  HtmlShellOptions,
+  "title" | "description" | "favicon" | "css" | "js"
+> = {
+  title: "Test",
+  description: "Test",
+  favicon: "/favicon.ico",
+  css: "style.css",
+  js: "app.js",
+};
+
+/**
+ * Create a full HtmlShellOptions from a custom body + extra fields.
+ */
+export function htmlOpts(body: string, overrides?: Partial<HtmlShellOptions>): HtmlShellOptions {
+  return { ...BASE_HTML_OPTS, body, ...overrides } as HtmlShellOptions;
+}
+
+// ─── DevServerContext shortcut ──────────────────────────
+
+import type { DevServerContext } from "../node/plugin";
+
+export function devCtx(overrides?: Partial<DevServerContext>): DevServerContext {
+  return { port: 3000, hostname: "localhost", ...overrides };
+}
+
+// ─── PageContext shortcut ───────────────────────────────
+
+import type { PageContext } from "../node/plugin";
+
+export function pageCtx(overrides?: Partial<PageContext>): PageContext {
+  return {
+    slug: "test",
+    filePath: "test.mdx",
+    frontmatter: {},
+    content: "",
+    config: createMinimalConfig() as any,
+    ...overrides,
+  } as PageContext;
+}
+
+// ─── Mock Plugin: tracks all 10 hooks ───────────────────
+
+export interface HookLog {
+  hook: string;
+  args: unknown[];
+  timestamp: number;
+}
+
+export interface MockPlugin extends DocuBookPlugin {
+  logs: HookLog[];
+}
+
+export function createMockPlugin(name: string): MockPlugin {
+  const logs: HookLog[] = [];
+
+  const log = (hook: string, ...args: unknown[]) => {
+    logs.push({ hook, args, timestamp: Date.now() });
+  };
+
+  return {
+    name,
+    logs,
+    setup(build) {
+      log("setup");
+
+      build.onStart((config) => {
+        log("onStart", config);
+      });
+
+      build.onLoad({ filter: /\.mdx$/ }, ({ path: filePath, content }) => {
+        log("onLoad", filePath);
+        return {
+          contents: content.replace(/\bHello\b/g, "Hi"),
+          loader: "js",
+        };
+      });
+
+      build.transformFrontmatter((frontmatter, ctx) => {
+        log("transformFrontmatter", ctx.slug);
+        return { ...frontmatter, processed: true, pluginName: name };
+      });
+
+      build.injectHead((ctx) => {
+        log("injectHead", ctx.slug);
+        return `<meta name="plugin" content="${name}">`;
+      });
+
+      build.injectBody((ctx) => {
+        log("injectBody", ctx.slug);
+        return '<div id="plugin-widget">Plugin Widget</div>';
+      });
+
+      build.remarkPlugins(() => {
+        log("remarkPlugins");
+        return [];
+      });
+
+      build.rehypePlugins(() => {
+        log("rehypePlugins");
+        return [];
+      });
+
+      build.transformHtml((html, ctx) => {
+        log("transformHtml", ctx.slug);
+        return html.replace("</body>", "<!-- Plugin Footer -->\n</body>");
+      });
+
+      build.onEnd((_config, pages) => {
+        log("onEnd", pages.length);
+      });
+
+      build.handleRequest((req, _ctx) => {
+        log("handleRequest", req.url);
+        return undefined;
+      });
+    },
+  };
+}
+
+// ─── Faulty plugin factory ──────────────────────────────
+
+export function createFaultyPlugin(
+  hook: "onStart" | "handleRequest" | "injectHead"
+): DocuBookPlugin {
+  const errorMsg = `${hook} failure`;
+  return {
+    name: "faulty",
+    setup(build) {
+      if (hook === "onStart") {
+        build.onStart(() => {
+          throw new Error(errorMsg);
+        });
+      } else if (hook === "handleRequest") {
+        build.handleRequest(() => {
+          throw new Error(errorMsg);
+        });
+      } else if (hook === "injectHead") {
+        build.injectHead(() => {
+          throw new Error(errorMsg);
+        });
+      }
+    },
+  };
+}

--- a/packages/flame/.docu/__tests__/mdx.test.ts
+++ b/packages/flame/.docu/__tests__/mdx.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Pluggable } from "unified";
+
+// ─── Capture serialize calls ─────────────────────────────
+
+let lastSerializeOptions: {
+  rehypePlugins?: Pluggable[];
+  remarkPlugins?: Pluggable[];
+} | null = null;
+
+// ─── Mock @docubook/core ───────────────────────────────────
+
+vi.mock("@docubook/core", () => {
+  const defaultRemarkPlugins: Pluggable[] = [{ name: "defaultRemark" } as any];
+  const defaultRehypePlugins: Pluggable[] = [{ name: "defaultRehype" } as any];
+
+  return {
+    createDefaultRemarkPlugins: () => [...defaultRemarkPlugins],
+    createDefaultRehypePlugins: () => [...defaultRehypePlugins],
+    extractTocsFromRawMdx: () => [],
+    extractFrontmatterWithContent: <T>() => ({
+      frontmatter: {} as unknown as T,
+      strippedContent: "<p>test</p>",
+    }),
+    serialize: async (
+      _content: string,
+      opts?: { mdxOptions?: { rehypePlugins?: Pluggable[]; remarkPlugins?: Pluggable[] } }
+    ) => {
+      lastSerializeOptions = {
+        remarkPlugins: opts?.mdxOptions?.remarkPlugins,
+        rehypePlugins: opts?.mdxOptions?.rehypePlugins,
+      };
+      return { compiledSource: "/* compiled */" };
+    },
+    MDXRemote: vi.fn(() => null),
+  };
+});
+
+vi.mock("@docubook/mdx-content", () => ({
+  createMdxComponents: () => ({}),
+}));
+
+vi.mock("../node/utils", () => ({
+  getGitLastModified: vi.fn(() => null),
+  getGitLastModifiedBatch: vi.fn(() => new Map()),
+}));
+
+// Import after mocks
+import { compileMdx } from "../node/mdx";
+import type { MdxResult } from "../node/mdx";
+
+describe("compileMdx — plugin merging", () => {
+  const sampleMdx = "---\ntitle: Test\n---\n\nHello world";
+
+  beforeEach(() => {
+    lastSerializeOptions = null;
+  });
+
+  it("uses only defaults when no plugins passed", async () => {
+    await compileMdx(sampleMdx, "test.mdx");
+    expect(lastSerializeOptions).not.toBeNull();
+    expect(lastSerializeOptions!.remarkPlugins).toHaveLength(1);
+    expect(lastSerializeOptions!.remarkPlugins![0].name).toBe("defaultRemark");
+    expect(lastSerializeOptions!.rehypePlugins).toHaveLength(1);
+    expect(lastSerializeOptions!.rehypePlugins![0].name).toBe("defaultRehype");
+  });
+
+  it("uses only defaults when empty arrays passed", async () => {
+    await compileMdx(sampleMdx, "test.mdx", undefined, [], []);
+    expect(lastSerializeOptions!.remarkPlugins).toHaveLength(1);
+    expect(lastSerializeOptions!.rehypePlugins).toHaveLength(1);
+  });
+
+  it("merges remark plugins after defaults", async () => {
+    const extraRemark: Pluggable[] = [{ name: "customRemark" } as any];
+    await compileMdx(sampleMdx, "test.mdx", undefined, extraRemark);
+    expect(lastSerializeOptions!.remarkPlugins).toHaveLength(2);
+    expect(lastSerializeOptions!.remarkPlugins![0].name).toBe("defaultRemark");
+    expect(lastSerializeOptions!.remarkPlugins![1].name).toBe("customRemark");
+  });
+
+  it("merges rehype plugins after defaults", async () => {
+    const extraRehype: Pluggable[] = [{ name: "customRehype" } as any];
+    await compileMdx(sampleMdx, "test.mdx", undefined, undefined, extraRehype);
+    expect(lastSerializeOptions!.rehypePlugins).toHaveLength(2);
+    expect(lastSerializeOptions!.rehypePlugins![0].name).toBe("defaultRehype");
+    expect(lastSerializeOptions!.rehypePlugins![1].name).toBe("customRehype");
+  });
+
+  it("merges both remark and rehype plugins together", async () => {
+    const extraRemark: Pluggable[] = [{ name: "customRemark" } as any];
+    const extraRehype: Pluggable[] = [{ name: "customRehype" } as any];
+    await compileMdx(sampleMdx, "test.mdx", undefined, extraRemark, extraRehype);
+    expect(lastSerializeOptions!.remarkPlugins).toHaveLength(2);
+    expect(lastSerializeOptions!.rehypePlugins).toHaveLength(2);
+  });
+
+  it("preserves MdxResult shape", async () => {
+    const result: MdxResult = await compileMdx(sampleMdx, "test.mdx");
+    expect(result).toHaveProperty("content");
+    expect(result).toHaveProperty("compiledSource");
+    expect(result).toHaveProperty("frontmatter");
+    expect(result).toHaveProperty("tocs");
+  });
+});

--- a/packages/flame/.docu/__tests__/plugin-integration.test.ts
+++ b/packages/flame/.docu/__tests__/plugin-integration.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "vitest";
+import { htmlShell } from "../node/html";
+import { createBuilder, createMockPlugin, createFaultyPlugin, pageCtx, htmlOpts } from "./helpers";
+
+// ─── Integration: Loader + Builder together ──────────────
+
+describe("Plugin lifecycle — loader + builder integration", () => {
+  it("loads plugin, sets up builder, executes all hooks in order", async () => {
+    const plugin = createMockPlugin("test-integration");
+    const builder = createBuilder(["test-integration"]);
+
+    await plugin.setup(builder);
+
+    expect(plugin.logs.some((l) => l.hook === "setup")).toBe(true);
+
+    // [1] onStart
+    await builder.runOnStart();
+    expect(plugin.logs.find((l) => l.hook === "onStart")).toBeDefined();
+
+    // [2] onLoad
+    const loadResult = await builder.runOnLoad("/path/to/page.mdx", "Hello World");
+    expect(loadResult?.contents).toBe("Hi World");
+    const loadNoMatch = await builder.runOnLoad("/path/to/data.json", "Hello");
+    expect(loadNoMatch).toBeNull();
+
+    // [3] transformFrontmatter
+    const fm = await builder.runTransformFrontmatterChain(
+      { title: "Test" },
+      { slug: "page", filePath: "page.mdx" }
+    );
+    expect(fm.processed).toBe(true);
+    expect(fm.pluginName).toBe("test-integration");
+    expect(fm.title).toBe("Test");
+
+    // [4-5] injectHead / injectBody
+    const ctx = pageCtx({ slug: "page", filePath: "page.mdx", frontmatter: fm as any });
+    const headExtra = builder.collectHead(ctx);
+    const bodyExtra = builder.collectBody(ctx);
+    expect(headExtra).toContain('<meta name="plugin" content="test-integration">');
+    expect(bodyExtra).toContain('<div id="plugin-widget">Plugin Widget</div>');
+
+    // [6-7] remark / rehype
+    expect(builder.collectRemarkPlugins()).toEqual([]);
+    expect(builder.collectRehypePlugins()).toEqual([]);
+
+    // [8] transformHtml
+    const html = await builder.runTransformHtmlChain(
+      "<html><body><p>Content</p></body></html>",
+      ctx
+    );
+    expect(html).toContain("<!-- Plugin Footer -->");
+
+    // [9] onEnd
+    const pages = [
+      { slug: "page", title: "Page", filePath: "page.mdx", outputPath: "dist/page.html" },
+    ];
+    await builder.runOnEnd(pages);
+    const onEndLog = plugin.logs.find((l) => l.hook === "onEnd");
+    expect(onEndLog!.args[0]).toBe(1);
+
+    // [10] handleRequest
+    const result = await builder.runHandleRequest(new Request("http://test.dev/api/plugin"), {
+      port: 3000,
+      hostname: "localhost",
+    });
+    expect(result).toBeNull();
+
+    // Verify execution order
+    const order = plugin.logs.filter((l) => l.hook !== "setup").map((l) => l.hook);
+
+    const expectedOrder = [
+      "onStart",
+      "onLoad",
+      "transformFrontmatter",
+      "injectHead",
+      "injectBody",
+      "remarkPlugins",
+      "rehypePlugins",
+      "transformHtml",
+      "onEnd",
+      "handleRequest",
+    ];
+
+    let lastIdx = -1;
+    for (const hook of expectedOrder) {
+      const idx = order.indexOf(hook);
+      expect(idx).toBeGreaterThan(lastIdx);
+      lastIdx = idx;
+    }
+
+    expect(plugin.logs.filter((l) => l.hook === "onStart")).toHaveLength(1);
+  });
+});
+
+// ─── Integration: builder + html.ts ──────────────────────
+
+describe("Plugin integration — HTML output", () => {
+  it("includes plugin head/body injections in final HTML", async () => {
+    const plugin = createMockPlugin("html-plugin");
+    const builder = createBuilder(["html-plugin"]);
+    plugin.setup(builder);
+
+    const ctx = pageCtx({ slug: "test-page", filePath: "test-page.mdx" });
+    const headExtra = builder.collectHead(ctx);
+    const bodyExtra = builder.collectBody(ctx);
+
+    const html = htmlShell(htmlOpts("<p>Content</p>", { headExtra, bodyExtra }));
+
+    // Head injection position
+    expect(html).toContain('<meta name="plugin" content="html-plugin">');
+    expect(html.indexOf('<meta name="plugin"')).toBeLessThan(html.indexOf("</head>"));
+
+    // Body injection position
+    expect(html).toContain('<div id="plugin-widget">Plugin Widget</div>');
+    expect(html.indexOf('<div id="plugin-widget"')).toBeLessThan(html.indexOf("</body>"));
+
+    // transformHtml
+    const transformed = await builder.runTransformHtmlChain(html, ctx);
+    expect(transformed).toContain("<!-- Plugin Footer -->");
+    expect(transformed.indexOf("<!-- Plugin Footer -->")).toBeLessThan(
+      transformed.indexOf("</body>")
+    );
+  });
+});
+
+// ─── No-op mode: zero plugins ───────────────────────────
+
+describe("Plugin integration — no-op mode", () => {
+  it("all operations succeed without throwing", async () => {
+    const builder = createBuilder();
+
+    await expect(
+      (async () => {
+        await builder.runOnStart();
+        await builder.runOnLoad("page.mdx", "content");
+        await builder.runTransformFrontmatterChain({}, { slug: "p", filePath: "p.mdx" });
+        await builder.runTransformHtmlChain("<p>test</p>", {} as any);
+        await builder.runOnEnd([]);
+      })()
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns empty arrays when no plugins registered", () => {
+    const builder = createBuilder();
+    expect(builder.collectHead({} as any)).toEqual([]);
+    expect(builder.collectBody({} as any)).toEqual([]);
+    expect(builder.collectRemarkPlugins()).toEqual([]);
+    expect(builder.collectRehypePlugins()).toEqual([]);
+    expect(builder.runOnLoad("page.mdx", "content")).resolves.toBeNull();
+  });
+});
+
+// ─── Multiple plugins integration ───────────────────────
+
+describe("Plugin integration — multiple plugins", () => {
+  it("executes hooks from multiple plugins in registration order", async () => {
+    const pluginA = createMockPlugin("plugin-a");
+    const pluginB = createMockPlugin("plugin-b");
+    const builder = createBuilder(["plugin-a", "plugin-b"]);
+
+    await pluginA.setup(builder);
+    await pluginB.setup(builder);
+    await builder.runOnStart();
+
+    expect(pluginA.logs.find((l) => l.hook === "onStart")).toBeDefined();
+    expect(pluginB.logs.find((l) => l.hook === "onStart")).toBeDefined();
+
+    const ctx = pageCtx({ slug: "multi", filePath: "multi.mdx" });
+    const headExtra = builder.collectHead(ctx);
+    expect(headExtra.filter((h) => h.includes("plugin-a"))).toHaveLength(1);
+    expect(headExtra.filter((h) => h.includes("plugin-b"))).toHaveLength(1);
+
+    const html = await builder.runTransformHtmlChain("<html><body>Content</body></html>", ctx);
+    expect(html).toContain("<!-- Plugin Footer -->");
+  });
+});
+
+// ─── Error isolation ─────────────────────────────────────
+
+describe("Plugin integration — error isolation", () => {
+  it("onStart fail-fast propagates error", async () => {
+    const builder = createBuilder(["faulty"]);
+    await createFaultyPlugin("onStart").setup(builder);
+    await expect(builder.runOnStart()).rejects.toThrow("onStart failure");
+  });
+
+  it("handleRequest isolates errors", async () => {
+    const builder = createBuilder(["faulty", "working"]);
+    const working = createMockPlugin("working");
+    await createFaultyPlugin("handleRequest").setup(builder);
+    await working.setup(builder);
+
+    const before = working.logs.length;
+    const result = await builder.runHandleRequest(new Request("http://test.dev"), {
+      port: 3000,
+      hostname: "localhost",
+    });
+    expect(result).toBeNull();
+    expect(working.logs.length).toBeGreaterThan(before);
+  });
+
+  it("injectHead fail-fast propagates error", async () => {
+    const builder = createBuilder(["faulty"]);
+    await createFaultyPlugin("injectHead").setup(builder);
+    expect(() => builder.collectHead({} as any)).toThrow("injectHead failure");
+  });
+});

--- a/packages/flame/.docu/__tests__/plugin-loader.test.ts
+++ b/packages/flame/.docu/__tests__/plugin-loader.test.ts
@@ -4,7 +4,7 @@ import { loadPlugins, resolveSpecifier } from "../node/plugin-loader";
 
 // ─── Fixtures path helper ────────────────────────────────
 
-const FIXTURES = "./.docu/__tests__/fixtures";
+const FIXTURES = "./packages/flame/.docu/__tests__/fixtures";
 
 function fixture(file: string) {
   return `${FIXTURES}/${file}.ts`;

--- a/packages/flame/.docu/__tests__/plugin-loader.test.ts
+++ b/packages/flame/.docu/__tests__/plugin-loader.test.ts
@@ -4,7 +4,7 @@ import { loadPlugins, resolveSpecifier } from "../node/plugin-loader";
 
 // ─── Fixtures path helper ────────────────────────────────
 
-const FIXTURES = "./packages/flame/.docu/__tests__/fixtures";
+const FIXTURES = "./.docu/__tests__/fixtures";
 
 function fixture(file: string) {
   return `${FIXTURES}/${file}.ts`;

--- a/packages/flame/.docu/__tests__/plugin-loader.test.ts
+++ b/packages/flame/.docu/__tests__/plugin-loader.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { loadPlugins, resolveSpecifier } from "../node/plugin-loader";
+
+// ─── Fixtures path helper ────────────────────────────────
+
+const FIXTURES = "./packages/flame/.docu/__tests__/fixtures";
+
+function fixture(file: string) {
+  return `${FIXTURES}/${file}.ts`;
+}
+
+const SIMPLE = fixture("simple-plugin");
+const FACTORY = fixture("factory-plugin");
+const INVALID_STRING = fixture("invalid-string");
+const MISSING_NAME = fixture("missing-name");
+const MISSING_SETUP = fixture("missing-setup");
+
+// ─── resolveSpecifier ───────────────────────────────────
+
+describe("resolveSpecifier", () => {
+  const ROOT = process.cwd();
+
+  it("resolves relative paths from project root", () => {
+    expect(resolveSpecifier("./plugins/my-plugin.ts")).toBe(
+      resolve(ROOT, "./plugins/my-plugin.ts")
+    );
+  });
+
+  it("keeps absolute paths unchanged", () => {
+    expect(resolveSpecifier("/usr/lib/plugin.mjs")).toBe("/usr/lib/plugin.mjs");
+  });
+
+  it("keeps npm package names unchanged", () => {
+    expect(resolveSpecifier("@docubook/plugin-sitemap")).toBe("@docubook/plugin-sitemap");
+  });
+
+  it("resolves parent-relative paths", () => {
+    expect(resolveSpecifier("../other-pkg/plugin.mjs")).toBe(
+      resolve(ROOT, "../other-pkg/plugin.mjs")
+    );
+  });
+});
+
+// ─── loadPlugins — edge cases ───────────────────────────
+
+describe("loadPlugins — edge cases", () => {
+  it("returns empty array for undefined entries", async () => {
+    expect(await loadPlugins(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for empty entries", async () => {
+    expect(await loadPlugins([])).toEqual([]);
+  });
+
+  it("throws on unresolvable import path", async () => {
+    await expect(loadPlugins(["./non-existent-plugin-that-does-not-exist.mjs"])).rejects.toThrow(
+      "[plugin-loader] Failed to import plugin"
+    );
+  });
+
+  it("throws on non-existent npm package", async () => {
+    await expect(loadPlugins(["@docubook/non-existent-plugin-xyz-123"])).rejects.toThrow(
+      "[plugin-loader] Failed to import plugin"
+    );
+  });
+
+  it("throws when default export is a string", async () => {
+    await expect(loadPlugins([INVALID_STRING])).rejects.toThrow(
+      "must export a default function or object"
+    );
+  });
+});
+
+// ─── loadPlugins — simple object pattern ─────────────────
+
+describe("loadPlugins — simple object pattern", () => {
+  /** Load the simple-plugin fixture and verify its identity. */
+  async function assertSimple(file: string) {
+    const plugins = await loadPlugins([file]);
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].name).toBe("fixture-simple");
+    expect(typeof plugins[0].setup).toBe("function");
+  }
+
+  it("loads from relative path", () => assertSimple(SIMPLE));
+
+  it("loads from absolute path", async () => {
+    const abs = resolve(process.cwd(), SIMPLE);
+    await assertSimple(abs);
+  });
+});
+
+// ─── loadPlugins — factory function pattern ─────────────
+
+describe("loadPlugins — factory function pattern", () => {
+  it("loads without options", async () => {
+    const plugins = await loadPlugins([FACTORY]);
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].name).toBe("fixture-factory");
+  });
+
+  it("loads with options via tuple syntax", async () => {
+    const plugins = await loadPlugins([[FACTORY, { name: "custom-name" }]]);
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].name).toBe("custom-name");
+  });
+
+  it("resolves mixed array (simple + factory)", async () => {
+    const plugins = await loadPlugins([SIMPLE, [FACTORY, { name: "factory-instance" }]]);
+    expect(plugins).toHaveLength(2);
+    expect(plugins[0].name).toBe("fixture-simple");
+    expect(plugins[1].name).toBe("factory-instance");
+  });
+});
+
+// ─── loadPlugins — validation errors ─────────────────────
+
+describe("loadPlugins — validation errors", () => {
+  it("throws when name is missing", async () => {
+    await expect(loadPlugins([MISSING_NAME])).rejects.toThrow("must have a valid 'name' property");
+  });
+
+  it("throws when setup function is missing", async () => {
+    await expect(loadPlugins([MISSING_SETUP])).rejects.toThrow(
+      "must have a 'setup(build)' function"
+    );
+  });
+});

--- a/packages/flame/.docu/__tests__/plugin.test.ts
+++ b/packages/flame/.docu/__tests__/plugin.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BuildPluginBuilder } from "../node/plugin-builder";
+import { htmlShell } from "../node/html";
+import { createBuilder, pageCtx, htmlOpts, devCtx } from "./helpers";
+import type { Pluggable } from "unified";
+
+// ─── PluginBuilder Registration Tests ────────────────────
+
+describe("BuildPluginBuilder — Registration", () => {
+  let builder: BuildPluginBuilder;
+
+  beforeEach(() => {
+    builder = createBuilder();
+  });
+
+  it("stores config on construction", () => {
+    expect(builder.config).toBeDefined();
+    expect(builder.config.meta.title).toBe("Test");
+  });
+
+  function expectRegisterMethod(method: keyof BuildPluginBuilder) {
+    const cb = vi.fn();
+    (builder[method] as (...args: unknown[]) => unknown)(cb);
+    expect(typeof builder[method]).toBe("function");
+  }
+
+  it("registers onStart callbacks", () => expectRegisterMethod("onStart"));
+  it("registers onEnd callbacks", () => expectRegisterMethod("onEnd"));
+
+  it("registers onLoad handlers with filter", () => {
+    const cb = vi.fn();
+    builder.onLoad({ filter: /\.mdx$/ }, cb);
+    expect(typeof builder.onLoad).toBe("function");
+  });
+
+  it("registers transformFrontmatter callbacks", () =>
+    expectRegisterMethod("transformFrontmatter"));
+  it("registers transformHtml callbacks", () => expectRegisterMethod("transformHtml"));
+  it("registers injectHead callbacks", () => expectRegisterMethod("injectHead"));
+  it("registers injectBody callbacks", () => expectRegisterMethod("injectBody"));
+  it("registers remarkPlugins callbacks", () => expectRegisterMethod("remarkPlugins"));
+  it("registers rehypePlugins callbacks", () => expectRegisterMethod("rehypePlugins"));
+  it("registers handleRequest callbacks", () => expectRegisterMethod("handleRequest"));
+});
+
+// ─── PluginBuilder Execution Tests ───────────────────────
+
+describe("BuildPluginBuilder — Execution", () => {
+  let builder: BuildPluginBuilder;
+
+  beforeEach(() => {
+    builder = createBuilder();
+  });
+
+  const pageCtxFor = (slug: string) => pageCtx({ slug, filePath: `${slug}.mdx` });
+
+  describe("runOnStart", () => {
+    it("calls registered callbacks in order", async () => {
+      const order: number[] = [];
+      builder.onStart(async () => {
+        order.push(1);
+      });
+      builder.onStart(async () => {
+        order.push(2);
+      });
+      builder.onStart(async () => {
+        order.push(3);
+      });
+      await builder.runOnStart();
+      expect(order).toEqual([1, 2, 3]);
+    });
+
+    it("passes config to callbacks", async () => {
+      const spy = vi.fn();
+      builder.onStart(spy);
+      await builder.runOnStart();
+      expect(spy).toHaveBeenCalledWith(builder.config);
+    });
+
+    it("awaits async callbacks", async () => {
+      let resolved = false;
+      builder.onStart(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        resolved = true;
+      });
+      await builder.runOnStart();
+      expect(resolved).toBe(true);
+    });
+
+    it("resolves when no callbacks registered", async () => {
+      await expect(builder.runOnStart()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("runOnEnd", () => {
+    it("calls callbacks with config and pages", async () => {
+      const spy = vi.fn();
+      const pages = [
+        { slug: "test", title: "Test", filePath: "/test.mdx", outputPath: "/test.html" },
+      ];
+      builder.onEnd(spy);
+      await builder.runOnEnd(pages);
+      expect(spy).toHaveBeenCalledWith(builder.config, pages);
+    });
+  });
+
+  describe("runOnLoad", () => {
+    it("matches file by filter regex", async () => {
+      const spy = vi.fn(({ content }: { content: string }) => ({
+        contents: content.toUpperCase(),
+      }));
+      builder.onLoad({ filter: /\.mdx$/ }, spy);
+      const result = await builder.runOnLoad("/path/to/page.mdx", "hello world");
+      expect(result).toEqual({ contents: "HELLO WORLD" });
+    });
+
+    it("skips files not matching filter", async () => {
+      const spy = vi.fn();
+      builder.onLoad({ filter: /\.mdx$/ }, spy);
+      const result = await builder.runOnLoad("/path/to/data.json", "{}");
+      expect(result).toBeNull();
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("first matching handler wins", async () => {
+      const spy1 = vi.fn(() => ({ contents: "from-first" }));
+      builder.onLoad({ filter: /\.md$/ }, spy1);
+      builder.onLoad(
+        { filter: /\.md$/ },
+        vi.fn(() => ({ contents: "from-second" }))
+      );
+      const result = await builder.runOnLoad("page.md", "original");
+      expect(result).toEqual({ contents: "from-first" });
+    });
+
+    it("returns null when handler returns void", async () => {
+      builder.onLoad({ filter: /.*/ }, () => {});
+      const result = await builder.runOnLoad("page.md", "content");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("runTransformFrontmatterChain", () => {
+    it("chains transforms in waterfall pattern", async () => {
+      builder.transformFrontmatter((fm) => ({ ...fm, a: 1 }));
+      builder.transformFrontmatter((fm) => ({ ...fm, b: fm.a }));
+      const result = await builder.runTransformFrontmatterChain({}, pageCtxFor("test"));
+      expect(result).toEqual({ a: 1, b: 1 });
+    });
+
+    it("preserves original when callback returns void", async () => {
+      builder.transformFrontmatter(() => {});
+      const result = await builder.runTransformFrontmatterChain(
+        { original: true },
+        pageCtxFor("test")
+      );
+      expect(result).toEqual({ original: true });
+    });
+  });
+
+  describe("runTransformHtmlChain", () => {
+    it("chains HTML transforms", async () => {
+      builder.transformHtml((html) => html.replace("foo", "bar"));
+      builder.transformHtml((html) => `<wrapper>${html}</wrapper>`);
+      const result = await builder.runTransformHtmlChain("<p>foo</p>", null as any);
+      expect(result).toBe("<wrapper><p>bar</p></wrapper>");
+    });
+  });
+
+  describe("collectHead / collectBody", () => {
+    const noCtx = null as any;
+
+    it("collects and deduplicates head injections", () => {
+      builder.injectHead(() => '<script src="a.js"></script>');
+      builder.injectHead(() => '<script src="b.js"></script>');
+      builder.injectHead(() => '<script src="a.js"></script>');
+      expect(builder.collectHead(noCtx)).toEqual([
+        '<script src="a.js"></script>',
+        '<script src="b.js"></script>',
+      ]);
+    });
+
+    it("collects body injections", () => {
+      builder.injectBody(() => '<div id="chat"></div>');
+      expect(builder.collectBody(noCtx)).toEqual(['<div id="chat"></div>']);
+    });
+
+    it("returns empty array when no callbacks registered", () => {
+      expect(builder.collectHead(noCtx)).toEqual([]);
+      expect(builder.collectBody(noCtx)).toEqual([]);
+    });
+
+    it("handles array return from callback", () => {
+      builder.injectHead(() => ["<meta a>", "<meta b>"]);
+      expect(builder.collectHead(noCtx)).toEqual(["<meta a>", "<meta b>"]);
+    });
+  });
+
+  describe("collectRemarkPlugins / collectRehypePlugins", () => {
+    it("collects remark plugins", () => {
+      const plugin1 = {} as Pluggable;
+      const plugin2 = {} as Pluggable;
+      builder.remarkPlugins(() => [plugin1]);
+      builder.remarkPlugins(() => [plugin2]);
+      expect(builder.collectRemarkPlugins()).toEqual([plugin1, plugin2]);
+    });
+
+    it("collects rehype plugins", () => {
+      const plugin = {} as Pluggable;
+      builder.rehypePlugins(() => [plugin]);
+      expect(builder.collectRehypePlugins()).toEqual([plugin]);
+    });
+
+    it("returns empty array when no plugins registered", () => {
+      expect(builder.collectRemarkPlugins()).toEqual([]);
+      expect(builder.collectRehypePlugins()).toEqual([]);
+    });
+  });
+
+  describe("runHandleRequest", () => {
+    const defaultReq = new Request("http://test.dev");
+    const defaultCtx = devCtx();
+
+    it("short-circuits on first Response", async () => {
+      const responseA = new Response("A");
+      builder.handleRequest(() => responseA);
+      builder.handleRequest(() => new Response("B"));
+      const result = await builder.runHandleRequest(defaultReq, defaultCtx);
+      expect(result).toBe(responseA);
+    });
+
+    it("returns null when no handler returns Response", async () => {
+      builder.handleRequest(() => {});
+      const result = await builder.runHandleRequest(defaultReq, defaultCtx);
+      expect(result).toBeNull();
+    });
+
+    it("continues to next handler on error", async () => {
+      const spy = vi.fn(() => new Response("ok"));
+      builder.handleRequest(() => {
+        throw new Error("fail");
+      });
+      builder.handleRequest(spy);
+      const result = await builder.runHandleRequest(defaultReq, defaultCtx);
+      expect(result).toBeInstanceOf(Response);
+      expect(await result!.text()).toBe("ok");
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it("passes request and context to handler", async () => {
+      const spy = vi.fn();
+      builder.handleRequest(spy);
+      await builder.runHandleRequest(
+        new Request("http://test.dev/api"),
+        devCtx({ port: 4000, hostname: "0.0.0.0" })
+      );
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ url: "http://test.dev/api" }), {
+        port: 4000,
+        hostname: "0.0.0.0",
+      });
+    });
+  });
+});
+
+// ─── HTML Injection Tests ────────────────────────────────
+
+describe("html.ts — headExtra / bodyExtra", () => {
+  /** Shell with default opts, replacing body only. */
+  function shell(body: string, ...rest: Partial<Parameters<typeof htmlShell>[0]>[]) {
+    return htmlShell(htmlOpts(body, ...rest));
+  }
+
+  it("renders headExtra inside <head>", () => {
+    const html = shell("<p>hello</p>", { headExtra: ['<meta name="test" content="1">'] });
+    expect(html).toContain('<meta name="test" content="1">');
+    expect(html.indexOf('<meta name="test"')).toBeLessThan(html.indexOf("</head>"));
+  });
+
+  it("renders bodyExtra before </body> after script", () => {
+    const html = shell("<p>hello</p>", { bodyExtra: ['<div id="chat"></div>'] });
+    expect(html).toContain('<div id="chat"></div>');
+    const bodyClose = html.indexOf("</body>");
+    expect(html.indexOf('<div id="chat"')).toBeLessThan(bodyClose);
+    expect(html.indexOf('src="/assets/app.js"')).toBeLessThan(html.indexOf('<div id="chat"'));
+  });
+
+  it("produces identical output when headExtra/bodyExtra are empty", () => {
+    const withEmpty = shell("<p>hello</p>", { headExtra: [], bodyExtra: [] });
+    const without = shell("<p>hello</p>");
+    expect(withEmpty).toBe(without);
+  });
+
+  it("renders multiple headExtra entries", () => {
+    const html = shell("<p>hello</p>", { headExtra: ["<meta a>", "<meta b>", "<meta c>"] });
+    expect(html).toContain("<meta a>");
+    expect(html).toContain("<meta b>");
+    expect(html).toContain("<meta c>");
+  });
+});
+
+// ─── Full Plugin Lifecycle Integration ───────────────────
+
+describe("Full Plugin Lifecycle", () => {
+  let builder: BuildPluginBuilder;
+
+  beforeEach(() => {
+    builder = createBuilder();
+  });
+
+  it("executes full lifecycle in correct order", async () => {
+    const order: string[] = [];
+
+    builder.onStart(() => {
+      order.push("onStart");
+    });
+    builder.onLoad({ filter: /\.mdx$/ }, ({ content }) => {
+      order.push("onLoad");
+      return { contents: content.toUpperCase() };
+    });
+    builder.transformFrontmatter((fm) => {
+      order.push("transformFrontmatter");
+      return { ...fm, processed: true };
+    });
+    builder.injectHead(() => {
+      order.push("injectHead");
+      return "";
+    });
+    builder.injectBody(() => {
+      order.push("injectBody");
+      return "";
+    });
+    builder.transformHtml((html) => {
+      order.push("transformHtml");
+      return html;
+    });
+    builder.onEnd(() => {
+      order.push("onEnd");
+    });
+
+    await builder.runOnStart();
+    const loadResult = await builder.runOnLoad("page.mdx", "content");
+    const fmResult = await builder.runTransformFrontmatterChain(
+      {},
+      { slug: "page", filePath: "page.mdx", content: "" }
+    );
+    builder.collectHead(null as any);
+    builder.collectBody(null as any);
+    await builder.runTransformHtmlChain("<p>test</p>", null as any);
+    await builder.runOnEnd([]);
+
+    expect(loadResult?.contents).toBe("CONTENT");
+    expect(fmResult).toEqual({ processed: true });
+
+    const idx = (h: string) => order.indexOf(h);
+    expect(idx("onStart")).toBeLessThan(idx("onLoad"));
+    expect(idx("onLoad")).toBeLessThan(idx("transformFrontmatter"));
+    expect(idx("transformFrontmatter")).toBeLessThan(idx("injectHead"));
+    expect(idx("injectHead")).toBeLessThan(idx("injectBody"));
+    expect(idx("injectBody")).toBeLessThan(idx("transformHtml"));
+    expect(idx("transformHtml")).toBeLessThan(idx("onEnd"));
+  });
+});

--- a/packages/flame/.docu/__tests__/schema.test.ts
+++ b/packages/flame/.docu/__tests__/schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("docu.schema.json — plugins field", () => {
+  const schemaPath = join(import.meta.dirname, "..", "..", "docu.schema.json");
+  const schema: Record<string, unknown> = JSON.parse(readFileSync(schemaPath, "utf-8"));
+
+  it("is valid JSON", () => {
+    expect(() => JSON.parse(readFileSync(schemaPath, "utf-8"))).not.toThrow();
+  });
+
+  it("has a plugins property", () => {
+    const properties = schema.properties as Record<string, unknown>;
+    expect(properties.plugins).toBeDefined();
+  });
+
+  it("defines plugins as array type", () => {
+    const plugins = (schema.properties as Record<string, unknown>).plugins as Record<
+      string,
+      unknown
+    >;
+    expect(plugins.type).toBe("array");
+  });
+
+  it("validates string items (simple plugin names)", () => {
+    const plugins = (schema.properties as Record<string, unknown>).plugins as Record<
+      string,
+      unknown
+    >;
+    const items = plugins.items as Record<string, unknown>;
+    const oneOf = items.oneOf as Record<string, unknown>[];
+    const stringItem = oneOf.find((o: Record<string, unknown>) => o.type === "string");
+    expect(stringItem).toBeDefined();
+    expect(stringItem!.description).toContain("package name");
+  });
+
+  it("validates tuple items (factory with options)", () => {
+    const plugins = (schema.properties as Record<string, unknown>).plugins as Record<
+      string,
+      unknown
+    >;
+    const items = plugins.items as Record<string, unknown>;
+    const oneOf = items.oneOf as Record<string, unknown>[];
+    const tupleItem = oneOf.find((o: Record<string, unknown>) => o.type === "array");
+    expect(tupleItem).toBeDefined();
+    expect((tupleItem as Record<string, unknown>).minItems).toBe(2);
+    expect((tupleItem as Record<string, unknown>).maxItems).toBe(2);
+  });
+
+  it("is draft-07 compliant", () => {
+    expect(schema.$schema).toBe("http://json-schema.org/draft-07/schema#");
+  });
+});

--- a/packages/flame/.docu/__tests__/utils.test.ts
+++ b/packages/flame/.docu/__tests__/utils.test.ts
@@ -46,5 +46,5 @@ describe("getGitLastModifiedBatch", () => {
   });
 });
 
-// Import setelah mock setup
+// Import after mock setup
 import { getGitLastModifiedBatch } from "../node/utils";

--- a/packages/flame/.docu/node/build.ts
+++ b/packages/flame/.docu/node/build.ts
@@ -19,7 +19,10 @@ import { generateSearchIndex } from "./search-indexer";
 import { buildClientBundle, computeInlineThemeCss } from "./hydrate";
 import { logger } from "./logger";
 import { initSentry, captureException } from "./sentry";
+import { loadPlugins } from "./plugin-loader";
+import { BuildPluginBuilder } from "./plugin-builder";
 import type { BuildCache, CliArgs } from "./types";
+import type { PageMeta, PageContext } from "./plugin";
 import DocsPage from "../pages/docs/[[...slug]]";
 import IndexPage from "../pages/index";
 import NotFoundPage from "../pages/404";
@@ -97,7 +100,13 @@ let assetManifest = { js: "client.js", css: "client.css" };
 
 let inlineThemeCss: string | undefined;
 
-function htmlShell(title: string, description: string, body: string): string {
+function htmlShell(
+  title: string,
+  description: string,
+  body: string,
+  headExtra?: string[],
+  bodyExtra?: string[]
+): string {
   const favicon = docuConfig.meta?.favicon || "/favicon.ico";
   return createHtmlShell({
     title,
@@ -107,6 +116,8 @@ function htmlShell(title: string, description: string, body: string): string {
     css: assetManifest.css,
     js: assetManifest.js,
     themeCss: inlineThemeCss,
+    headExtra,
+    bodyExtra,
   });
 }
 
@@ -114,18 +125,41 @@ async function renderDocsPage(
   slug: string,
   rawMdx: string,
   filePath: string,
-  gitDates?: Map<string, string>
+  gitDates?: Map<string, string>,
+  builder?: BuildPluginBuilder
 ): Promise<string> {
+  // [5] build.onLoad({filter}) — transform raw content before compilation
+  let content = rawMdx;
+  if (builder) {
+    const transformed = await builder.runOnLoad(filePath, content);
+    if (transformed?.contents) {
+      content = transformed.contents;
+    }
+  }
+
   let result;
   try {
-    result = await compileMdx(rawMdx, filePath, gitDates);
+    // [7] Collect remark/rehype plugins from plugins and pass to compileMdx
+    const remarkPlugins = builder?.collectRemarkPlugins();
+    const rehypePlugins = builder?.collectRehypePlugins();
+    result = await compileMdx(content, filePath, gitDates, remarkPlugins, rehypePlugins);
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Unknown MDX error";
     throw new Error(`MDX Error in: docs/${slug}.mdx\n${msg}`, { cause: err });
   }
 
-  const title = result.frontmatter.title || slug || "Docs";
-  const description = result.frontmatter.description || "";
+  // [6] build.transformFrontmatter() — mutate frontmatter
+  let frontmatter = result.frontmatter as Record<string, unknown>;
+  if (builder) {
+    frontmatter = await builder.runTransformFrontmatterChain(frontmatter, {
+      slug,
+      filePath,
+      content,
+    });
+  }
+
+  const title = (frontmatter.title as string) || slug || "Docs";
+  const description = (frontmatter.description as string) || "";
   const slugParts = slug ? slug.split("/") : [];
 
   const page = React.createElement(
@@ -135,7 +169,7 @@ async function renderDocsPage(
       slug: slugParts,
       title,
       description,
-      date: result.frontmatter.date || undefined,
+      date: (frontmatter.date as string) || undefined,
       content: result.content,
       tocs: result.tocs,
       filePath,
@@ -145,7 +179,20 @@ async function renderDocsPage(
   );
 
   const body = renderToString(page);
-  return htmlShell(title, description, body);
+
+  // [8] build.injectHead() / injectBody() — collect injection strings
+  const ctx: PageContext = { slug, filePath, frontmatter, content, config: docuConfig };
+  const headExtra = builder?.collectHead(ctx);
+  const bodyExtra = builder?.collectBody(ctx);
+
+  let html = htmlShell(title, description, body, headExtra, bodyExtra);
+
+  // [9] build.transformHtml() — final HTML transform
+  if (builder) {
+    html = await builder.runTransformHtmlChain(html, ctx);
+  }
+
+  return html;
 }
 
 async function copyDirectoryRecursive(src: string, dest: string): Promise<void> {
@@ -205,6 +252,18 @@ async function build() {
     };
   }
 
+  // [1-3] Plugin setup phase
+  const hasPlugins = !!docuConfig.plugins?.length;
+  const builder = hasPlugins ? new BuildPluginBuilder(docuConfig) : null;
+  if (hasPlugins && builder) {
+    const plugins = await loadPlugins(docuConfig.plugins!);
+    for (const plugin of plugins) {
+      await plugin.setup(builder);
+    }
+    // [4] build.onStart(config)
+    await builder.runOnStart();
+  }
+
   logger.spinner.start("Building pages...");
   t = performance.now();
 
@@ -259,7 +318,13 @@ async function build() {
 
     buildTasks.push(async () => {
       try {
-        const html = await renderDocsPage(capturedFile.path, capturedRawMdx, relPath, gitDates);
+        const html = await renderDocsPage(
+          capturedFile.path,
+          capturedRawMdx,
+          relPath,
+          gitDates,
+          builder
+        );
         const outputPath = join(DIST_DIR, "docs", `${capturedFile.path}.html`);
         await mkdir(dirname(outputPath), { recursive: true });
         await writeFile(outputPath, html);
@@ -285,7 +350,7 @@ async function build() {
     const indexMdxPath = join(DOCS_DIR, "index.mdx");
     const indexRaw = await readFile(indexMdxPath, "utf-8");
     const indexRelPath = indexMdxPath.replace(PROJECT_ROOT + "/", "");
-    const indexHtml = await renderDocsPage("", indexRaw, indexRelPath, gitDates);
+    const indexHtml = await renderDocsPage("", indexRaw, indexRelPath, gitDates, builder);
     await mkdir(join(DIST_DIR, "docs"), { recursive: true });
     await writeFile(join(DIST_DIR, "docs", "index.html"), indexHtml);
   } catch (err) {
@@ -313,6 +378,17 @@ async function build() {
   logger.spinner.stop(
     `Built ${built} pages (${skipped} cached) \x1b[90m(${Math.round(performance.now() - t)}ms)\x1b[0m`
   );
+
+  // [10] build.onEnd(config, pages)
+  if (builder) {
+    const pages: PageMeta[] = mdxFiles.map((f) => ({
+      slug: f.path,
+      title: f.path.split("/").pop() || f.path,
+      filePath: join(DOCS_DIR, f.path),
+      outputPath: join(DIST_DIR, "docs", `${f.path}.html`),
+    }));
+    await builder.runOnEnd(pages);
+  }
 
   logger.indexStart();
   t = performance.now();

--- a/packages/flame/.docu/node/html.ts
+++ b/packages/flame/.docu/node/html.ts
@@ -8,12 +8,30 @@ export interface HtmlShellOptions {
   nonce?: string;
   extraScripts?: string;
   themeCss?: string;
+  /** HTML strings to inject before `</head>` (from plugin `injectHead` hooks). */
+  headExtra?: string[];
+  /** HTML strings to inject before `</body>`, after the main script (from plugin `injectBody` hooks). */
+  bodyExtra?: string[];
 }
 
 export function htmlShell(opts: HtmlShellOptions): string {
-  const { title, description, body, favicon, css, js, nonce, extraScripts, themeCss } = opts;
+  const {
+    title,
+    description,
+    body,
+    favicon,
+    css,
+    js,
+    nonce,
+    extraScripts,
+    themeCss,
+    headExtra,
+    bodyExtra,
+  } = opts;
   const nonceAttr = nonce ? ` nonce="${Bun.escapeHTML(nonce)}"` : "";
   const themeStyle = themeCss ? `\n  <style${nonceAttr}>${Bun.escapeHTML(themeCss)}</style>` : "";
+  const headInjection = headExtra?.length ? `\n  ${headExtra.join("\n  ")}` : "";
+  const bodyInjection = bodyExtra?.length ? `\n  ${bodyExtra.join("\n  ")}` : "";
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -23,11 +41,11 @@ export function htmlShell(opts: HtmlShellOptions): string {
   <meta name="description" content="${Bun.escapeHTML(description)}">
   <link rel="icon" type="image/x-icon" href="${Bun.escapeHTML(favicon)}">${themeStyle}
   <link rel="stylesheet" href="/assets/${Bun.escapeHTML(css)}">
-  <script${nonceAttr}>try{if(localStorage.getItem("theme")==="dark")document.documentElement.classList.add("dark")}catch(e){}</script>
+  <script${nonceAttr}>try{if(localStorage.getItem("theme")==="dark")document.documentElement.classList.add("dark")}catch(e){}</script>${headInjection}
 </head>
 <body>
   <div id="root">${body}</div>
-  <script${nonceAttr} src="/assets/${Bun.escapeHTML(js)}"></script>${extraScripts ? `\n  ${extraScripts}` : ""}
+  <script${nonceAttr} src="/assets/${Bun.escapeHTML(js)}"></script>${extraScripts ? `\n  ${extraScripts}` : ""}${bodyInjection}
 </body>
 </html>`;
 }

--- a/packages/flame/.docu/node/mdx.ts
+++ b/packages/flame/.docu/node/mdx.ts
@@ -1,4 +1,5 @@
 import React from "react";
+import type { Pluggable } from "unified";
 import {
   serialize,
   extractTocsFromRawMdx,
@@ -19,10 +20,21 @@ export interface MdxResult {
   tocs: ReturnType<typeof extractTocsFromRawMdx>;
 }
 
+/**
+ * Compile MDX/MD content into a React element and compiled source.
+ *
+ * @param rawMdx - Raw MDX/MD file content
+ * @param filePath - Relative file path for git date lookup
+ * @param gitDates - Optional pre-fetched git last-modified map
+ * @param remarkPlugins - Additional remark plugins (merged after defaults, optional)
+ * @param rehypePlugins - Additional rehype plugins (merged after defaults, optional)
+ */
 export async function compileMdx(
   rawMdx: string,
   filePath: string,
-  gitDates?: Map<string, string>
+  gitDates?: Map<string, string>,
+  remarkPlugins?: Pluggable[],
+  rehypePlugins?: Pluggable[]
 ): Promise<MdxResult> {
   const tocs = extractTocsFromRawMdx(rawMdx);
   const { frontmatter, strippedContent } = extractFrontmatterWithContent<{
@@ -31,10 +43,16 @@ export async function compileMdx(
     date?: string;
   }>(rawMdx);
 
+  const defaultRemark = createDefaultRemarkPlugins();
+  const defaultRehype = createDefaultRehypePlugins();
+
+  const finalRemark = remarkPlugins?.length ? [...defaultRemark, ...remarkPlugins] : defaultRemark;
+  const finalRehype = rehypePlugins?.length ? [...defaultRehype, ...rehypePlugins] : defaultRehype;
+
   const serialized = await serialize(strippedContent, {
     mdxOptions: {
-      rehypePlugins: createDefaultRehypePlugins(),
-      remarkPlugins: createDefaultRemarkPlugins(),
+      rehypePlugins: finalRehype,
+      remarkPlugins: finalRemark,
     },
   });
 

--- a/packages/flame/.docu/node/plugin-builder.ts
+++ b/packages/flame/.docu/node/plugin-builder.ts
@@ -1,0 +1,270 @@
+import type { Pluggable } from "unified";
+import type { DocuConfig, PageContext, PageMeta, DevServerContext, PluginBuilder } from "./plugin";
+
+// ─── Utility Types ───────────────────────────────────────
+
+type Awaitable<T> = T | Promise<T>;
+
+// ─── Internal Handler Storage Types ──────────────────────
+
+interface OnLoadHandler {
+  filter: RegExp;
+  namespace?: string;
+  fn: (args: {
+    path: string;
+    content: string;
+  }) => Awaitable<{ contents?: string; loader?: "js" | "ts" | "mdx" } | void>;
+}
+
+// ─── BuildPluginBuilder ──────────────────────────────────
+
+export class BuildPluginBuilder implements PluginBuilder {
+  readonly config: DocuConfig;
+
+  private _handleRequest: Array<
+    (req: Request, context: DevServerContext) => Awaitable<Response | void>
+  > = [];
+  private _injectBody: Array<(context: PageContext) => string | string[]> = [];
+  private _injectHead: Array<(context: PageContext) => string | string[]> = [];
+  private _onEnd: Array<(config: DocuConfig, pages: PageMeta[]) => Awaitable<void>> = [];
+  private _onLoad: OnLoadHandler[] = [];
+  private _onStart: Array<(config: DocuConfig) => Awaitable<void>> = [];
+  private _rehypePlugins: Array<() => Pluggable[]> = [];
+  private _remarkPlugins: Array<() => Pluggable[]> = [];
+  private _transformFrontmatter: Array<
+    (
+      frontmatter: Record<string, unknown>,
+      context: Pick<PageContext, "slug" | "filePath" | "content">
+    ) => Awaitable<Record<string, unknown> | void>
+  > = [];
+  private _transformHtml: Array<(html: string, context: PageContext) => Awaitable<string>> = [];
+
+  constructor(config: DocuConfig) {
+    this.config = config;
+  }
+
+  collectBody(context: PageContext): string[] {
+    const items: string[] = [];
+    for (const cb of this._injectBody) {
+      try {
+        const result = cb(context);
+        if (result) {
+          if (Array.isArray(result)) {
+            items.push(...result);
+          } else {
+            items.push(result);
+          }
+        }
+      } catch (err) {
+        throw new Error(
+          `[plugin] injectBody callback failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err }
+        );
+      }
+    }
+    return [...new Set(items)];
+  }
+
+  collectHead(context: PageContext): string[] {
+    const items: string[] = [];
+    for (const cb of this._injectHead) {
+      try {
+        const result = cb(context);
+        if (result) {
+          if (Array.isArray(result)) {
+            items.push(...result);
+          } else {
+            items.push(result);
+          }
+        }
+      } catch (err) {
+        throw new Error(
+          `[plugin] injectHead callback failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err }
+        );
+      }
+    }
+    return [...new Set(items)];
+  }
+
+  collectRehypePlugins(): Pluggable[] {
+    const plugins: Pluggable[] = [];
+    for (const cb of this._rehypePlugins) {
+      try {
+        plugins.push(...cb());
+      } catch (err) {
+        throw new Error(
+          `[plugin] rehypePlugins callback failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err }
+        );
+      }
+    }
+    return plugins;
+  }
+
+  collectRemarkPlugins(): Pluggable[] {
+    const plugins: Pluggable[] = [];
+    for (const cb of this._remarkPlugins) {
+      try {
+        plugins.push(...cb());
+      } catch (err) {
+        throw new Error(
+          `[plugin] remarkPlugins callback failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err }
+        );
+      }
+    }
+    return plugins;
+  }
+
+  handleRequest(
+    callback: (req: Request, context: DevServerContext) => Awaitable<Response | void>
+  ): void {
+    this._handleRequest.push(callback);
+  }
+
+  injectBody(callback: (context: PageContext) => string | string[]): void {
+    this._injectBody.push(callback);
+  }
+
+  injectHead(callback: (context: PageContext) => string | string[]): void {
+    this._injectHead.push(callback);
+  }
+
+  onEnd(callback: (config: DocuConfig, pages: PageMeta[]) => Awaitable<void>): void {
+    this._onEnd.push(callback);
+  }
+
+  onLoad(
+    args: { filter: RegExp; namespace?: string },
+    callback: (args: {
+      path: string;
+      content: string;
+    }) => Awaitable<{ contents?: string; loader?: "js" | "ts" | "mdx" } | void>
+  ): void {
+    this._onLoad.push({ ...args, fn: callback });
+  }
+
+  onStart(callback: (config: DocuConfig) => Awaitable<void>): void {
+    this._onStart.push(callback);
+  }
+
+  rehypePlugins(callback: () => Pluggable[]): void {
+    this._rehypePlugins.push(callback);
+  }
+
+  remarkPlugins(callback: () => Pluggable[]): void {
+    this._remarkPlugins.push(callback);
+  }
+
+  async runHandleRequest(req: Request, context: DevServerContext): Promise<Response | null> {
+    for (let i = 0; i < this._handleRequest.length; i++) {
+      try {
+        const result = await this._handleRequest[i](req, context);
+        if (result instanceof Response) {
+          return result;
+        }
+      } catch (err) {
+        console.error(
+          `[plugin] handleRequest callback #${i + 1} error: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+    return null;
+  }
+
+  async runOnEnd(pages: PageMeta[]): Promise<void> {
+    for (let i = 0; i < this._onEnd.length; i++) {
+      try {
+        await this._onEnd[i](this.config, pages);
+      } catch (err) {
+        throw new Error(
+          `[plugin] onEnd callback #${i + 1} failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err }
+        );
+      }
+    }
+  }
+
+  async runOnLoad(
+    path: string,
+    content: string
+  ): Promise<{ contents?: string; loader?: "js" | "ts" | "mdx" } | null> {
+    for (const handler of this._onLoad) {
+      if (handler.filter.test(path)) {
+        try {
+          const result = await handler.fn({ path, content });
+          if (result) return result;
+        } catch (err) {
+          throw new Error(
+            `[plugin] onLoad handler for filter ${handler.filter} failed: ${err instanceof Error ? err.message : String(err)}`,
+            { cause: err }
+          );
+        }
+      }
+    }
+    return null;
+  }
+
+  async runOnStart(): Promise<void> {
+    for (let i = 0; i < this._onStart.length; i++) {
+      try {
+        await this._onStart[i](this.config);
+      } catch (err) {
+        throw new Error(
+          `[plugin] onStart callback #${i + 1} failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err }
+        );
+      }
+    }
+  }
+
+  async runTransformFrontmatterChain(
+    frontmatter: Record<string, unknown>,
+    context: Pick<PageContext, "slug" | "filePath" | "content">
+  ): Promise<Record<string, unknown>> {
+    let result = frontmatter;
+    for (let i = 0; i < this._transformFrontmatter.length; i++) {
+      try {
+        const next = await this._transformFrontmatter[i](result, context);
+        if (next !== undefined && next !== null) {
+          result = next;
+        }
+      } catch (err) {
+        throw new Error(
+          `[plugin] transformFrontmatter callback #${i + 1} failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err }
+        );
+      }
+    }
+    return result;
+  }
+
+  async runTransformHtmlChain(html: string, context: PageContext): Promise<string> {
+    let result = html;
+    for (let i = 0; i < this._transformHtml.length; i++) {
+      try {
+        result = await this._transformHtml[i](result, context);
+      } catch (err) {
+        throw new Error(
+          `[plugin] transformHtml callback #${i + 1} failed: ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err }
+        );
+      }
+    }
+    return result;
+  }
+
+  transformFrontmatter(
+    callback: (
+      frontmatter: Record<string, unknown>,
+      context: Pick<PageContext, "slug" | "filePath" | "content">
+    ) => Awaitable<Record<string, unknown> | void>
+  ): void {
+    this._transformFrontmatter.push(callback);
+  }
+
+  transformHtml(callback: (html: string, context: PageContext) => Awaitable<string>): void {
+    this._transformHtml.push(callback);
+  }
+}

--- a/packages/flame/.docu/node/plugin-loader.ts
+++ b/packages/flame/.docu/node/plugin-loader.ts
@@ -1,0 +1,97 @@
+import { resolve } from "node:path";
+import { PROJECT_ROOT } from "./paths";
+import type { DocuBookPlugin, PluginEntry } from "./plugin";
+
+/**
+ * Resolve a plugin specifier to an absolute path or npm package name.
+ *
+ * Resolution rules:
+ * 1. Relative path (starts with `.`) → resolve from project root
+ * 2. Absolute path (starts with `/`) → use as-is
+ * 3. Anything else → treat as npm package name (handled by Bun's import)
+ */
+/** @internal Exported for testing only. */
+export function resolveSpecifier(specifier: string): string {
+  if (specifier.startsWith(".")) {
+    return resolve(PROJECT_ROOT, specifier);
+  }
+  return specifier; // npm package or absolute path
+}
+
+/**
+ * Load and instantiate all plugins from a config entries array.
+ *
+ * @param entries - Array of plugin entries from `docu.json`.
+ *   Each entry is either:
+ *   - a `string` (plugin specifier, no options)
+ *   - a `[string, object]` tuple (plugin specifier + factory options)
+ * @returns Array of resolved `DocuBookPlugin` instances.
+ *
+ * @throws If a plugin specifier cannot be imported.
+ * @throws If a plugin's default export lacks a `name` property.
+ *
+ * @example
+ * const plugins = await loadPlugins([
+ *   "@docubook/plugin-sitemap",
+ *   ["@docubook/plugin-analytics", { id: "G-XXXXXXX" }],
+ *   "./plugins/local-reading-time",
+ * ]);
+ */
+export async function loadPlugins(entries: PluginEntry[] = []): Promise<DocuBookPlugin[]> {
+  const plugins: DocuBookPlugin[] = [];
+
+  for (const entry of entries) {
+    const [specifier, options] = Array.isArray(entry) ? entry : [entry, undefined];
+    const resolved = resolveSpecifier(specifier);
+
+    let mod: Record<string, unknown>;
+    try {
+      mod = await import(resolved);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`[plugin-loader] Failed to import plugin "${specifier}": ${message}`, {
+        cause: err,
+      });
+    }
+
+    const exported = mod.default as unknown;
+
+    let plugin: DocuBookPlugin;
+
+    if (typeof exported === "function") {
+      // Factory pattern: exported function receives options, returns DocuBookPlugin
+      try {
+        plugin = (exported as (opts?: Record<string, unknown>) => DocuBookPlugin)(options);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `[plugin-loader] Plugin factory "${specifier}" threw during initialization: ${message}`,
+          { cause: err }
+        );
+      }
+    } else if (exported && typeof exported === "object") {
+      // Simple pattern: exported object is (or duck-types as) DocuBookPlugin
+      plugin = exported as DocuBookPlugin;
+    } else {
+      throw new Error(
+        `[plugin-loader] Plugin "${specifier}" must export a default function or object. Got: ${typeof exported}`
+      );
+    }
+
+    if (!plugin.name || typeof plugin.name !== "string") {
+      throw new Error(
+        `[plugin-loader] Plugin "${specifier}" must have a valid 'name' property (string). Got: ${typeof plugin.name}`
+      );
+    }
+
+    if (typeof plugin.setup !== "function") {
+      throw new Error(
+        `[plugin-loader] Plugin "${specifier}" (name: "${plugin.name}") must have a 'setup(build)' function.`
+      );
+    }
+
+    plugins.push(plugin);
+  }
+
+  return plugins;
+}

--- a/packages/flame/.docu/node/plugin.ts
+++ b/packages/flame/.docu/node/plugin.ts
@@ -1,0 +1,264 @@
+import type { Pluggable } from "unified";
+
+// ─── Config Types ───────────────────────────────────────
+
+/**
+ * Plugin entry in `docu.json` config.
+ * - `string`: plugin package name or relative path (no options)
+ * - `[string, object]`: plugin package name + factory options
+ *
+ * @example "@docubook/plugin-sitemap"
+ * @example ["@docubook/plugin-search-algolia", { appId: "xxx" }]
+ */
+export type PluginEntry = string | [string, Record<string, unknown>];
+
+// ─── Context Types ──────────────────────────────────────
+
+/**
+ * Context passed to content-transform hooks for a single page.
+ */
+export interface PageContext {
+  /** Relative slug path: "getting-started/introduction" */
+  slug: string;
+  /** Absolute file path on disk */
+  filePath: string;
+  /** Parsed frontmatter metadata */
+  frontmatter: Record<string, unknown>;
+  /** Raw MDX/MD content (only available in `transformFrontmatter` when enabled) */
+  content?: string;
+  /** Resolved site configuration */
+  config: DocuConfig;
+}
+
+/**
+ * Metadata for a single built page, aggregated and passed to `onEnd`.
+ */
+export interface PageMeta {
+  /** URL slug: "getting-started/introduction" */
+  slug: string;
+  /** Page title from frontmatter or filename */
+  title: string;
+  /** Absolute source file path */
+  filePath: string;
+  /** Relative output path under dist */
+  outputPath: string;
+}
+
+/**
+ * Context passed to the dev server request handler.
+ */
+export interface DevServerContext {
+  /** Dev server port */
+  port: number;
+  /** Dev server hostname */
+  hostname: string;
+}
+
+// ─── PluginBuilder Interface ────────────────────────────
+
+/**
+ * Builder object passed to each plugin's `setup()` function.
+ *
+ * Follows Bun's `PluginBuilder` convention:
+ * - Plugins register lifecycle callbacks through typed methods
+ * - Callbacks are executed sequentially in registration order
+ * - `config` provides read-only access to the resolved build config
+ */
+export interface PluginBuilder {
+  /** Resolved DocuBook configuration (read-only after setup phase). */
+  config: DocuConfig;
+
+  // ─── Build Lifecycle ───────────────────────────────────
+
+  /**
+   * Register a callback to run once before the build starts.
+   * Use for: validating config, initializing resources, fetching remote data.
+   *
+   * @param callback - Receives the resolved config. May return a Promise.
+   *
+   * @example
+   * build.onStart((config) => {
+   *   if (!config.meta.baseURL) throw new Error("baseURL required");
+   * });
+   */
+  onStart(callback: (config: DocuConfig) => void | Promise<void>): void;
+
+  /**
+   * Register a callback to run once after all pages are built.
+   * Use for: generating sitemaps, RSS feeds, manifests, post-build reports.
+   *
+   * @param callback - Receives config and aggregated page metadata. May return a Promise.
+   *
+   * @example
+   * build.onEnd((config, pages) => {
+   *   const xml = generateSitemap(pages, config.meta.baseURL);
+   *   await Bun.write(join(DIST_DIR, "sitemap.xml"), xml);
+   * });
+   */
+  onEnd(callback: (config: DocuConfig, pages: PageMeta[]) => void | Promise<void>): void;
+
+  // ─── Content Transform ─────────────────────────────────
+
+  /**
+   * Register a callback to transform raw file content before MDX compilation.
+   * Similar to Bun's `build.onLoad()` — filtered by file path pattern.
+   *
+   * Use for: preprocessing MDX/MD, injecting frontmatter, code transformations.
+   *
+   * @param args.filter - RegExp matched against the file's relative path
+   * @param args.namespace - Optional namespace prefix (reserved for future use)
+   * @param callback - Receives file path and raw content. Return new contents or void.
+   *
+   * @example
+   * build.onLoad({ filter: /\.md$/ }, ({ path, content }) => {
+   *   return { contents: `<!-- auto-processed -->\n${content}` };
+   * });
+   */
+  onLoad(
+    args: { filter: RegExp; namespace?: string },
+    callback: (args: {
+      path: string;
+      content: string;
+    }) => { contents?: string; loader?: "js" | "ts" | "mdx" } | void
+  ): void;
+
+  /**
+   * Register a callback to mutate frontmatter before MDX compilation.
+   * Callbacks are chained: the return value of one is passed as input to the next.
+   *
+   * Use for: injecting reading-time, validating fields, adding computed metadata.
+   *
+   * @param callback - Receives frontmatter object and page context. Return mutated frontmatter or void.
+   *
+   * @example
+   * build.transformFrontmatter((fm, ctx) => {
+   *   const wordCount = ctx.content!.split(/\s+/).length;
+   *   return { ...fm, readingTime: `${Math.ceil(wordCount / 200)} min read` };
+   * });
+   */
+  transformFrontmatter(
+    callback: (
+      frontmatter: Record<string, unknown>,
+      context: Pick<PageContext, "slug" | "filePath" | "content">
+    ) => Record<string, unknown> | void
+  ): void;
+
+  /**
+   * Register a callback to transform the final HTML string per page.
+   * This is the **last** hook before the HTML is written to disk.
+   *
+   * Use for: post-processing, minification, link rewriting, custom injection.
+   *
+   * @param callback - Receives HTML string and full page context. Return modified HTML.
+   *
+   * @example
+   * build.transformHtml((html, ctx) => {
+   *   return html.replace(/https?:\/\/old-domain\.com\//g, "/");
+   * });
+   */
+  transformHtml(callback: (html: string, context: PageContext) => string | Promise<string>): void;
+
+  // ─── Head & Script Injection ───────────────────────────
+
+  /**
+   * Register a callback that returns HTML strings to inject inside `<head>`.
+   * Results from all plugins are merged and deduplicated.
+   *
+   * Use for: analytics snippets, meta tags, stylesheet links.
+   *
+   * @param callback - Returns a single HTML string or an array. Called once per page.
+   *
+   * @example
+   * build.injectHead(() => {
+   *   return `<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXX"></script>`;
+   * });
+   */
+  injectHead(callback: (context: PageContext) => string | string[]): void;
+
+  /**
+   * Register a callback that returns HTML strings to inject before `</body>`.
+   * Results from all plugins are merged and deduplicated.
+   *
+   * Use for: chat widgets, live-script loaders, deferred scripts.
+   *
+   * @param callback - Returns a single HTML string or an array. Called once per page.
+   */
+  injectBody(callback: (context: PageContext) => string | string[]): void;
+
+  // ─── MDX Pipeline Extension ────────────────────────────
+
+  /**
+   * Register additional remark (Markdown) plugins for the MDX compilation pipeline.
+   * Plugins from all plugins are merged and applied **after** the default set.
+   *
+   * @example
+   * build.remarkPlugins(() => [require("remark-custom-heading-id")]);
+   */
+  remarkPlugins(callback: () => Pluggable[]): void;
+
+  /**
+   * Register additional rehype (HTML) plugins for the MDX compilation pipeline.
+   * Plugins from all plugins are merged and applied **after** the default set.
+   *
+   * @example
+   * build.rehypePlugins(() => [require("rehype-autolink-headings")]);
+   */
+  rehypePlugins(callback: () => Pluggable[]): void;
+
+  // ─── Dev Server ────────────────────────────────────────
+
+  /**
+   * Register a callback to intercept incoming requests during development.
+   * The **first** callback to return a `Response` short-circuits all subsequent handlers.
+   *
+   * Use for: custom API routes, mock data endpoints, redirects, request logging.
+   *
+   * @param callback - Receives the Request and dev server context. Return Response or void.
+   *
+   * @example
+   * build.handleRequest((req, ctx) => {
+   *   if (new URL(req.url).pathname === "/api/status") {
+   *     return new Response(JSON.stringify({ ok: true }), {
+   *       headers: { "Content-Type": "application/json" },
+   *     });
+   *   }
+   * });
+   */
+  handleRequest(
+    callback: (
+      req: Request,
+      context: DevServerContext
+    ) => Response | void | Promise<Response | void>
+  ): void;
+}
+
+// ─── Plugin Interface ────────────────────────────────────
+
+/**
+ * A DocuBook plugin.
+ *
+ * Follows Bun's `BunPlugin` convention:
+ * - `name`: unique identifier for the plugin
+ * - `setup(build)`: called once to register lifecycle hooks via the provided `PluginBuilder`
+ *
+ * @example
+ * const myPlugin: DocuBookPlugin = {
+ *   name: "analytics",
+ *   setup(build) {
+ *     build.injectHead(() => `<script>...</script>`);
+ *     build.onEnd(() => console.log("build done"));
+ *   },
+ * };
+ */
+export interface DocuBookPlugin {
+  /** Unique plugin name. Used in error messages and logs. */
+  name: string;
+
+  /**
+   * Called once after all plugins are loaded and before the build begins.
+   * Register all lifecycle hooks via the `build` (PluginBuilder) parameter.
+   *
+   * @param build - The PluginBuilder instance for this build session.
+   */
+  setup(build: PluginBuilder): void | Promise<void>;
+}

--- a/packages/flame/.docu/node/server.ts
+++ b/packages/flame/.docu/node/server.ts
@@ -7,6 +7,8 @@ import { renderToString } from "react-dom/server";
 import { getContentType } from "./utils";
 import { compileMdx } from "./mdx";
 import { DOCS_DIR, DIST_DIR, PAGES_DIR, PROJECT_ROOT, loadDocuConfig } from "./paths";
+import { loadPlugins } from "./plugin-loader";
+import { BuildPluginBuilder } from "./plugin-builder";
 import DocsPage from "../pages/docs/[[...slug]]";
 import NotFoundPage from "../pages/404";
 import IndexPage from "../pages/index";
@@ -39,6 +41,16 @@ const records = await generateSearchIndex();
 logger.indexDone(records, Math.round(performance.now() - t));
 
 logger.routes();
+
+// Plugin setup (dev server — only handleRequest is used; content hooks reused via build pipeline)
+const hasPlugins = !!docuConfig.plugins?.length;
+const builder = hasPlugins ? new BuildPluginBuilder(docuConfig) : null;
+if (hasPlugins && builder) {
+  const plugins = await loadPlugins(docuConfig.plugins!);
+  for (const plugin of plugins) {
+    await plugin.setup(builder);
+  }
+}
 
 let router: InstanceType<typeof Bun.FileSystemRouter> | null = null;
 try {
@@ -259,6 +271,23 @@ const server = Bun.serve({
     const url = new URL(req.url);
     const pathname = url.pathname;
     const startTime = performance.now();
+
+    // [1] Plugin handleRequest — short-circuit on first Response
+    if (builder) {
+      const pluginResponse = await builder.runHandleRequest(req, {
+        port: server.port,
+        hostname: server.hostname,
+      });
+      if (pluginResponse) {
+        logger.request(
+          req.method,
+          pathname,
+          pluginResponse.status,
+          Math.round(performance.now() - startTime)
+        );
+        return pluginResponse;
+      }
+    }
 
     try {
       if (pathname === "/__hmr") {

--- a/packages/flame/.docu/node/types.ts
+++ b/packages/flame/.docu/node/types.ts
@@ -67,6 +67,7 @@ export interface HomeConfig {
 }
 
 import type { ThemeConfig } from "@docubook/themes-colors";
+import type { PluginEntry } from "./plugin";
 
 export interface DocuConfig {
   meta: DocuMeta;
@@ -78,6 +79,8 @@ export interface DocuConfig {
   themes?: {
     colors: ThemeConfig;
   };
+  /** List of DocuBook plugins to load. Empty by default — no-op when absent. */
+  plugins?: PluginEntry[];
 }
 
 export interface BuildCache {

--- a/packages/flame/PLUGIN_DESIGN.md
+++ b/packages/flame/PLUGIN_DESIGN.md
@@ -1,14 +1,16 @@
 # DocuBook Plugin System — Design Document
 
+> **Design alignment:** This plugin system follows Bun's universal plugin API conventions —`setup(build)` pattern, lifecycle hooks (`onStart`, `onEnd`, `onLoad`), `filter`/`namespace` matching, and `build.config` access. Domain-specific hooks (`transformFrontmatter`, `injectHead`, etc.) are registered via the same `PluginBuilder` pattern.
+
 ## 1. Design Goals
 
-|          Goal           |                    Rationale                     |
-| ----------------------- | ------------------------------------------------ |
-| **Zero-config default** | Tanpa plugin, behavior identik dengan sekarang   |
-| **Composable**          | Plugin bisa stack tanpa conflict                 |
-| **Type-safe**           | Full TypeScript interface, autocomplete di IDE   |
-| **Bun-native**          | Tidak perlu bundler compat layer (webpack/vite)  |
-| **Minimal surface**     | Hooks hanya di titik yang benar-benar dibutuhkan |
+|          Goal           |                     Rationale                     |
+| ----------------------- | ------------------------------------------------- |
+| **Zero-config default** | Without plugins, behavior is identical to current |
+| **Composable**          | Plugins can stack without conflict                |
+| **Type-safe**           | Full TypeScript interface, IDE autocomplete       |
+| **Bun-native**          | Adopts `setup(build)` pattern from Bun API        |
+| **Minimal surface**     | Hooks only at genuinely needed points             |
 
 ## 2. Plugin Interface
 
@@ -16,6 +18,7 @@
 // packages/flame/.docu/node/plugin.ts
 
 import type { Pluggable } from "unified";
+import type { BuildConfig } from "bun";
 
 export interface PageContext {
   /** Relative path: "getting-started/introduction" */
@@ -40,45 +43,99 @@ export interface DevServerContext {
   hostname: string;
 }
 
-export interface DocuBookPlugin {
-  name: string;
+/**
+ * PluginBuilder — analogous to Bun's PluginBuilder.
+ * Plugins register hooks through these methods inside `setup()`.
+ */
+export interface PluginBuilder {
+  /** Build config (set by framework before setup is called). */
+  config: DocuConfig;
 
   // ─── Build Lifecycle ───────────────────────────────────
   /** Called once before build starts. Setup resources, validate config. */
-  buildStart?(config: DocuConfig): void | Promise<void>;
+  onStart(callback: (config: DocuConfig) => void | Promise<void>): void;
 
   /** Called once after all pages are built. Generate sitemaps, manifests, etc. */
-  buildEnd?(config: DocuConfig, pages: PageMeta[]): void | Promise<void>;
+  onEnd(callback: (config: DocuConfig, pages: PageMeta[]) => void | Promise<void>): void;
 
   // ─── Content Transform ─────────────────────────────────
+  /**
+   * Transform file contents before MDX compilation.
+   * Similar to Bun's `onLoad` — filter by file pattern.
+   */
+  onLoad(
+    args: { filter: RegExp; namespace?: string },
+    callback: (args: { path: string; content: string }) => {
+      contents?: string;
+      loader?: "js" | "ts" | "mdx";
+    } | void,
+  ): void;
+
   /** Mutate frontmatter before MDX compilation. */
-  transformFrontmatter?(
-    frontmatter: Record<string, unknown>,
-    context: Pick<PageContext, "slug" | "filePath">
-  ): Record<string, unknown> | void;
+  transformFrontmatter(
+    callback: (
+      frontmatter: Record<string, unknown>,
+      context: Pick<PageContext, "slug" | "filePath" | "content">,
+    ) => Record<string, unknown> | void,
+  ): void;
 
   /** Transform final HTML string per page. Last chance to inject/modify. */
-  transformHtml?(html: string, context: PageContext): string | Promise<string>;
+  transformHtml(
+    callback: (html: string, context: PageContext) => string | Promise<string>,
+  ): void;
 
   // ─── Head & Script Injection ───────────────────────────
   /** Return HTML strings to inject inside <head>. */
-  injectHead?(context: PageContext): string | string[];
+  injectHead(callback: (context: PageContext) => string | string[]): void;
 
   /** Return HTML strings to inject before </body>. */
-  injectBody?(context: PageContext): string | string[];
+  injectBody(callback: (context: PageContext) => string | string[]): void;
 
   // ─── MDX Pipeline Extension ────────────────────────────
   /** Additional remark plugins to append to the pipeline. */
-  remarkPlugins?(): Pluggable[];
+  remarkPlugins(callback: () => Pluggable[]): void;
 
   /** Additional rehype plugins to append to the pipeline. */
-  rehypePlugins?(): Pluggable[];
+  rehypePlugins(callback: () => Pluggable[]): void;
 
   // ─── Dev Server ────────────────────────────────────────
   /** Hook into dev server request handling. Return Response to short-circuit. */
-  handleRequest?(req: Request, context: DevServerContext): Response | void | Promise<Response | void>;
+  handleRequest(
+    callback: (
+      req: Request,
+      context: DevServerContext,
+    ) => Response | void | Promise<Response | void>,
+  ): void;
+}
+
+/**
+ * DocuBookPlugin — follows BunPlugin conventions:
+ * - `name`: unique identifier
+ * - `setup(build)`: where hooks are registered via PluginBuilder
+ */
+export interface DocuBookPlugin {
+  name: string;
+  setup(build: PluginBuilder): void | Promise<void>;
 }
 ```
+
+### Key Design Decisions
+
+| Bun Plugin API                    | DocuBook Plugin API                   | Notes                                    |
+| --------------------------------- | ------------------------------------- | ---------------------------------------- |
+| `name + setup(build)`             | `name + setup(build)`                 | Identical convention                    |
+| `build.onStart(fn)`               | `build.onStart(fn)`                   | Identical                                |
+| `build.onEnd(fn)`                 | `build.onEnd(fn)`                     | Identical                                |
+| `build.onLoad({filter}, cb)`      | `build.onLoad({filter}, cb)`          | Same pattern, different context (file vs import) |
+| `build.onResolve({filter}, cb)`   | *(none — irrelevant for SSG)*          | DocuBook does not resolve module imports |
+| `build.config`                    | `build.config`                        | Identical                                |
+| *(none)*                          | `build.transformFrontmatter(cb)`      | Domain-specific: frontmatter             |
+| *(none)*                          | `build.transformHtml(cb)`             | Domain-specific: HTML final              |
+| *(none)*                          | `build.injectHead(cb)`                | Domain-specific: head injection          |
+| *(none)*                          | `build.injectBody(cb)`                | Domain-specific: body injection          |
+| *(none)*                          | `build.remarkPlugins(cb)`             | Domain-specific: MDX pipeline            |
+| *(none)*                          | `build.rehypePlugins(cb)`             | Domain-specific: MDX pipeline            |
+| *(none)*                          | `build.handleRequest(cb)`             | Domain-specific: dev server              |
 
 ## 3. Config Extension
 
@@ -100,17 +157,27 @@ export interface DocuBookPlugin {
 3. Relative path `"./plugins/my-plugin"` → resolve from project root
 
 **Plugin export convention:**
+
 ```ts
-// Factory pattern (with options)
+// Factory pattern (with options) — return a DocuBookPlugin
 export default function pluginSitemap(options?: SitemapOptions): DocuBookPlugin {
   return {
     name: "sitemap",
-    buildEnd(config, pages) { /* generate sitemap.xml */ },
+    setup(build) {
+      build.onEnd((config, pages) => {
+        /* generate sitemap.xml */
+      });
+    },
   };
 }
 
 // Simple pattern (no options)
-export default { name: "my-plugin", buildStart() { } } satisfies DocuBookPlugin;
+export default {
+  name: "my-plugin",
+  setup(build) {
+    build.onStart(() => console.log("build started"));
+  },
+} satisfies DocuBookPlugin;
 ```
 
 ## 4. Integration Points (Build Pipeline)
@@ -118,21 +185,28 @@ export default { name: "my-plugin", buildStart() { } } satisfies DocuBookPlugin;
 ```
 build()
 │
-├─ [1] loadPlugins(config.plugins)
-├─ [2] plugin.buildStart(config)          ← NEW
+├─ [1] loadPlugins(config.plugins)         → DocuBookPlugin[]
+│
+├─ [2] create PluginBuilder(config)
+├─ [3] for each plugin: plugin.setup(build) ← SETUP PHASE (registers all hooks)
+│
+├─ [4] build.onStart(config)               ← all registered onStart callbacks
 │
 ├─ findMdxFiles()
 ├─ buildClientBundle()
 │
 ├─ for each MDX file:
-│   ├─ [3] plugin.transformFrontmatter()  ← NEW
-│   ├─ compileMdx() with merged remark/rehype plugins  ← [4] plugin.remarkPlugins() / rehypePlugins()
+│   ├─ [5] build.onLoad({filter})          ← transform raw file content
+│   ├─ [6] build.transformFrontmatter()    ← mutate frontmatter
+│   ├─ compileMdx() with merged remark/rehype plugins
+│         ← [7] build.remarkPlugins() / build.rehypePlugins()
 │   ├─ renderToString()
-│   ├─ htmlShell() with injected head/body  ← [5] plugin.injectHead() / injectBody()
-│   └─ [6] plugin.transformHtml()         ← NEW
+│   ├─ htmlShell() with injected head/body
+│         ← [8] build.injectHead() / build.injectBody()
+│   └─ [9] build.transformHtml()           ← final HTML transform
 │
 ├─ generateSearchIndex()
-├─ [7] plugin.buildEnd(config, pages)     ← NEW
+├─ [10] build.onEnd(config, pages)         ← all registered onEnd callbacks
 └─ writeCache()
 ```
 
@@ -141,9 +215,9 @@ build()
 ```
 server.fetch(req)
 │
-├─ [1] plugin.handleRequest(req)  ← NEW (early return short-circuits)
+├─ [1] build.handleRequest(req)            ← early return short-circuits
 ├─ HMR / static / router (existing logic)
-├─ renderDocsPage() → same hooks [3-6] as build
+├─ renderDocsPage() → same hooks [5-9] as build
 └─ response
 ```
 
@@ -180,67 +254,73 @@ export async function loadPlugins(entries: PluginEntry[] = []): Promise<DocuBook
 }
 ```
 
-## 7. Hook Runner
+## 7. PluginBuilder Implementation
 
 ```ts
-// packages/flame/.docu/node/plugin-runner.ts
+// packages/flame/.docu/node/plugin-builder.ts
 
-export class PluginRunner {
-  constructor(private plugins: DocuBookPlugin[]) {}
+type Awaitable<T> = T | Promise<T>;
 
-  async buildStart(config: DocuConfig) {
-    for (const p of this.plugins) await p.buildStart?.(config);
+export class BuildPluginBuilder implements PluginBuilder {
+  config: DocuConfig;
+
+  private _onStart: Array<(config: DocuConfig) => Awaitable<void>> = [];
+  private _onEnd: Array<(config: DocuConfig, pages: PageMeta[]) => Awaitable<void>> = [];
+  private _onLoad: Array<{
+    filter: RegExp;
+    namespace?: string;
+    fn: (args: { path: string; content: string }) => Awaitable<{ contents?: string; loader?: string } | void>;
+  }> = [];
+  private _transformFrontmatter: Array<(...) => ...> = [];
+  private _transformHtml: Array<(html: string, ctx: PageContext) => Awaitable<string>> = [];
+  private _injectHead: Array<(ctx: PageContext) => string | string[]> = [];
+  private _injectBody: Array<(ctx: PageContext) => string | string[]> = [];
+  private _remarkPlugins: Array<() => Pluggable[]> = [];
+  private _rehypePlugins: Array<() => Pluggable[]> = [];
+  private _handleRequest: Array<(req: Request, ctx: DevServerContext) => Awaitable<Response | void>> = [];
+
+  constructor(config: DocuConfig) {
+    this.config = config;
   }
 
-  async buildEnd(config: DocuConfig, pages: PageMeta[]) {
-    for (const p of this.plugins) await p.buildEnd?.(config, pages);
+  // ─── Registration ──────────────────────────────────────
+  onStart(cb: (config: DocuConfig) => Awaitable<void>) { this._onStart.push(cb); }
+  onEnd(cb: (config: DocuConfig, pages: PageMeta[]) => Awaitable<void>) { this._onEnd.push(cb); }
+  onLoad(args: { filter: RegExp; namespace?: string }, cb: ...) { this._onLoad.push({ ...args, fn: cb }); }
+  transformFrontmatter(cb: ...) { this._transformFrontmatter.push(cb); }
+  transformHtml(cb: ...) { this._transformHtml.push(cb); }
+  injectHead(cb: ...) { this._injectHead.push(cb); }
+  injectBody(cb: ...) { this._injectBody.push(cb); }
+  remarkPlugins(cb: ...) { this._remarkPlugins.push(cb); }
+  rehypePlugins(cb: ...) { this._rehypePlugins.push(cb); }
+  handleRequest(cb: ...) { this._handleRequest.push(cb); }
+
+  // ─── Execution ─────────────────────────────────────────
+  async runOnStart() {
+    for (const cb of this._onStart) await cb(this.config);
   }
 
-  transformFrontmatter(fm: Record<string, unknown>, ctx: Pick<PageContext, "slug" | "filePath">) {
-    let result = fm;
-    for (const p of this.plugins) {
-      result = p.transformFrontmatter?.(result, ctx) ?? result;
-    }
-    return result;
+  async runOnEnd(pages: PageMeta[]) {
+    for (const cb of this._onEnd) await cb(this.config, pages);
   }
 
-  async transformHtml(html: string, ctx: PageContext) {
-    let result = html;
-    for (const p of this.plugins) {
-      result = (await p.transformHtml?.(result, ctx)) ?? result;
-    }
-    return result;
-  }
-
-  collectHead(ctx: PageContext): string[] {
-    return this.plugins.flatMap((p) => {
-      const r = p.injectHead?.(ctx);
-      return r ? (Array.isArray(r) ? r : [r]) : [];
-    });
-  }
-
-  collectBody(ctx: PageContext): string[] {
-    return this.plugins.flatMap((p) => {
-      const r = p.injectBody?.(ctx);
-      return r ? (Array.isArray(r) ? r : [r]) : [];
-    });
-  }
-
-  collectRemarkPlugins(): Pluggable[] {
-    return this.plugins.flatMap((p) => p.remarkPlugins?.() ?? []);
-  }
-
-  collectRehypePlugins(): Pluggable[] {
-    return this.plugins.flatMap((p) => p.rehypePlugins?.() ?? []);
-  }
-
-  async handleRequest(req: Request, ctx: DevServerContext): Promise<Response | null> {
-    for (const p of this.plugins) {
-      const res = await p.handleRequest?.(req, ctx);
-      if (res) return res;
+  async runOnLoad(path: string, content: string): Promise<{ contents?: string } | null> {
+    for (const h of this._onLoad) {
+      if (h.filter.test(path)) {
+        const result = await h.fn({ path, content });
+        if (result) return result;
+      }
     }
     return null;
   }
+
+  transformFrontmatterChain(fm: ..., ctx: ...) { ... }
+  async transformHtmlChain(html: string, ctx: PageContext) { ... }
+  collectHead(ctx: PageContext): string[] { ... }
+  collectBody(ctx: PageContext): string[] { ... }
+  collectRemarkPlugins(): Pluggable[] { ... }
+  collectRehypePlugins(): Pluggable[] { ... }
+  async runHandleRequest(req: Request, ctx: DevServerContext): Promise<Response | null> { ... }
 }
 ```
 
@@ -271,27 +351,27 @@ export class PluginRunner {
 
 ## 9. `htmlShell` Modification
 
-Current `htmlShell` hanya terima fixed options. Perlu extend untuk injection:
+Current `htmlShell` only accepts fixed options. Needs extension for injection:
 
 ```ts
 export interface HtmlShellOptions {
   // ... existing
-  headExtra?: string[];   // ← plugin.injectHead() results
-  bodyExtra?: string[];   // ← plugin.injectBody() results
+  headExtra?: string[];   // ← from injectHead callbacks
+  bodyExtra?: string[];   // ← from injectBody callbacks
 }
 ```
 
 Injection placement:
-- `headExtra` → sebelum `</head>`
-- `bodyExtra` → sebelum `</body>`, setelah main script
+- `headExtra` → before `</head>`
+- `bodyExtra` → before `</body>`, after the main script
 
 ## 10. Execution Order & Conflict Resolution
 
 |        Concern        |                        Strategy                         |
 | --------------------- | ------------------------------------------------------- |
-| **Plugin order**      | Array order di `docu.json` = execution order            |
-| **Hook chaining**     | Sequential (waterfall) untuk transform hooks            |
-| **Hook parallel**     | Tidak ada — semua sequential untuk predictability       |
+| **Plugin order**      | Array order in `docu.json` = `setup()` execution order  |
+| **Hook chaining**     | Sequential (waterfall) for transform hooks              |
+| **Hook parallel**     | None — all sequential for predictability                |
 | **Error handling**    | Plugin error = build error (fail fast, log plugin name) |
 | **Duplicate plugins** | Allowed (user responsibility)                           |
 
@@ -299,14 +379,18 @@ Injection placement:
 
 ### `@docubook/plugin-sitemap`
 ```ts
+import type { DocuBookPlugin } from "@docubook/flame";
+
 export default function pluginSitemap(opts?: { hostname?: string }): DocuBookPlugin {
   return {
     name: "sitemap",
-    async buildEnd(config, pages) {
-      const host = opts?.hostname || config.meta.baseURL;
-      const urls = pages.map((p) => `<url><loc>${host}/docs/${p.slug}</loc></url>`);
-      const xml = `<?xml version="1.0"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join("\n")}\n</urlset>`;
-      await Bun.write(join(DIST_DIR, "sitemap.xml"), xml);
+    setup(build) {
+      build.onEnd((config, pages) => {
+        const host = opts?.hostname || config.meta.baseURL;
+        const urls = pages.map((p) => `<url><loc>${host}/docs/${p.slug}</loc></url>`);
+        const xml = `<?xml version="1.0"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join("\n")}\n</urlset>`;
+        await Bun.write(join(DIST_DIR, "sitemap.xml"), xml);
+      });
     },
   };
 }
@@ -317,11 +401,13 @@ export default function pluginSitemap(opts?: { hostname?: string }): DocuBookPlu
 export default function pluginAnalytics(opts: { id: string }): DocuBookPlugin {
   return {
     name: "analytics",
-    injectHead() {
-      return `<script async src="https://www.googletagmanager.com/gtag/js?id=${opts.id}"></script>`;
-    },
-    injectBody() {
-      return `<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','${opts.id}');</script>`;
+    setup(build) {
+      build.injectHead(() => {
+        return `<script async src="https://www.googletagmanager.com/gtag/js?id=${opts.id}"></script>`;
+      });
+      build.injectBody(() => {
+        return `<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','${opts.id}');</script>`;
+      });
     },
   };
 }
@@ -329,36 +415,42 @@ export default function pluginAnalytics(opts: { id: string }): DocuBookPlugin {
 
 ### `@docubook/plugin-reading-time`
 ```ts
-export default { 
+export default {
   name: "reading-time",
-  transformFrontmatter(fm, ctx) {
-    // Inject reading time into frontmatter
-    // (would need raw content access — see Open Questions)
-    return { ...fm, readingTime: "3 min read" };
+  setup(build) {
+    build.transformFrontmatter((fm, ctx) => {
+      const wordCount = ctx.content.split(/\s+/).length;
+      const minutes = Math.max(1, Math.ceil(wordCount / 200));
+      return { ...fm, readingTime: `${minutes} min read` };
+    });
   },
 } satisfies DocuBookPlugin;
 ```
 
-## 12. Migration Path
+## 12. Lifecycle Hook Summary
 
-|    Phase    |                              Scope                               |  Breaking?  |
-| ----------- | ---------------------------------------------------------------- | ----------- |
-| **Phase 1** | Add `plugins` field to config + loader + runner (no-op if empty) | ❌           |
-| **Phase 2** | Wire hooks into build pipeline                                   | ❌           |
-| **Phase 3** | Wire hooks into dev server                                       | ❌           |
-| **Phase 4** | Extract built-in search as `@docubook/plugin-search`             | ⚠️ Optional |
+|       Hook        |              Trigger              |       Callback Signature        |                     Use Case                      |
+| ----------------- | --------------------------------- | ------------------------------- | ------------------------------------------------- |
+| `onStart`         | Before build begins               | `(config) => void`              | Validate config, initialize resources             |
+| `onLoad`          | Before file is read/compiled      | `({path, content}) => contents` | Transform raw MDX/MD before compilation           |
+| `transformFrontmatter` | After frontmatter parsed     | `(fm, ctx) => fm`               | Inject reading time, validate fields              |
+| `remarkPlugins`   | MDX compilation pipeline          | `() => Pluggable[]`             | Custom remark transforms                          |
+| `rehypePlugins`   | MDX compilation pipeline          | `() => Pluggable[]`             | Custom rehype transforms                          |
+| `injectHead`      | HTML shell generation             | `(ctx) => string`               | Analytics, meta tags, stylesheets                 |
+| `injectBody`      | HTML shell generation             | `(ctx) => string`               | Scripts, widgets                                  |
+| `transformHtml`   | Final HTML output                 | `(html, ctx) => html`           | Post-processing, minification, link rewriting     |
+| `handleRequest`   | Dev server request handler        | `(req, ctx) => Response`        | Custom API routes, mock data, redirects           |
+| `onEnd`           | After all pages built             | `(config, pages) => void`       | Sitemap, search index, RSS, manifests             |
 
 ## 13. Open Questions
 
 |  #  |                            Question                             |                                Options                                 |                                                    |
 | --- | --------------------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------- |
-| 1   | Should `transformFrontmatter` receive raw MDX content?          | A) Yes (enables reading-time). B) No (keep it pure metadata transform) |                                                    |
-| 2   | Should plugins access the build cache?                          | A) Yes (for incremental plugin builds). B) No (plugins are stateless)  |                                                    |
-| 3   | Plugin ordering: explicit `enforce: 'pre'                       | 'post'`?                                                               | A) Yes (like Vite). B) No (KISS, array order only) |
-| 4   | Should `handleRequest` support middleware chaining (next())?    | A) Yes (Express-style). B) No (first-response-wins)                    |                                                    |
-| 5   | Config validation: should plugins declare their options schema? | A) Yes (JSON Schema). B) No (runtime validation only)                  |                                                    |
-
----
+| 1   | Should `transformFrontmatter` receive raw MDX content?          | **A) Yes** (enables reading-time). B) No (keep it pure metadata)       |                                                    |
+| 2   | Should plugins access the build cache?                          | **B) No** — plugins stateless (manage own state via files)             |                                                    |
+| 3   | Plugin ordering: explicit `enforce: 'pre'                       | 'post'`?                                                               | **B) No** — KISS, array order only (like Bun)     |
+| 4   | Should `handleRequest` support middleware chaining (next())?    | **B) No** — first-response-wins (return `void` to pass to the next plugin) |                              |
+| 5   | Config validation: should plugins declare their options schema? | **B) No** — runtime validation only (plugin author's responsibility)   |                                                    |
 
 ## 14. Files to Create/Modify
 
@@ -366,7 +458,7 @@ export default {
 | -------------------------------- | ------ | ----------------------------- |
 | `.docu/node/plugin.ts`           | Create | Plugin interface + types      |
 | `.docu/node/plugin-loader.ts`    | Create | Config → plugin instances     |
-| `.docu/node/plugin-runner.ts`    | Create | Hook execution engine         |
+| `.docu/node/plugin-builder.ts`   | Create | PluginBuilder implementation  |
 | `.docu/node/types.ts`            | Modify | Add `plugins` to `DocuConfig` |
 | `.docu/node/build.ts`            | Modify | Wire hooks into build         |
 | `.docu/node/server.ts`           | Modify | Wire `handleRequest` hook     |
@@ -374,27 +466,3 @@ export default {
 | `.docu/node/mdx.ts`              | Modify | Merge plugin remark/rehype    |
 | `docu.schema.json`               | Modify | Add `plugins` schema          |
 | `.docu/__tests__/plugin.test.ts` | Create | Unit tests                    |
-
----
-
-Oke, saya lihat referensi skill-nya. Untuk fase desain plugin system ini, skill yang paling relevan adalah `architecture-design` dan `brainstorm-feature`. Tapi sebelum lanjut ke implementasi nanti, kita perlu jawab dulu **5 open questions** di design doc supaya tidak salah langkah.
-
-Berdasarkan arsitektur DocuBook yang sudah saya pelajari, ini rekomendasi saya:
-
-## Open Questions — Rekomendasi
-
-|  #  |                Question                |                       Rekomendasi                        |                                             Alasan                                             |                                                                                         |
-| --- | -------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| 1   | `transformFrontmatter` terima raw MDX? | **A) Yes** — pass raw content sebagai parameter tambahan | Enables reading-time, word-count, custom excerpt. Tanpa ini plugin terlalu terbatas.           |                                                                                         |
-| 2   | Plugin access build cache?             | **B) No** — plugins stateless                            | Plugin yang butuh state bisa manage sendiri (tulis file). Expose cache = coupling ke internal. |                                                                                         |
-| 3   | `enforce: 'pre'                        | 'post'`?                                                 | **B) No** — array order only                                                                   | KISS. DocuBook bukan Vite — plugin count akan kecil (3-5 max). Explicit ordering cukup. |
-| 4   | `handleRequest` middleware chaining?   | **B) First-response-wins**                               | Simpler mental model. Kalau plugin return Response, done. Kalau return void, next plugin.      |                                                                                         |
-| 5   | Plugin options schema validation?      | **B) No** — runtime only                                 | Over-engineering untuk v1. Plugin author validate sendiri di factory function.                 |                                                                                         |
-
----
-
-Mau kamu confirm/override keputusan di atas? Setelah itu saya bisa:
-
-1. Finalize design doc dengan keputusan final
-2. Store sebagai `decision` di memory
-3. Lanjut ke implementasi Phase 1 (interface + loader + runner + tests) menggunakan skill `implement-feature`

--- a/packages/flame/docu.schema.json
+++ b/packages/flame/docu.schema.json
@@ -118,6 +118,34 @@
       "description": "Documentation navigation routes. Leave empty for auto-detection from docs/ folder.",
       "items": { "$ref": "#/$defs/route" }
     },
+    "plugins": {
+      "type": "array",
+      "description": "List of DocuBook plugins to load",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "Plugin package name or relative path (e.g. @docubook/plugin-sitemap)"
+          },
+          {
+            "type": "array",
+            "description": "Plugin package name with factory options",
+            "items": [
+              {
+                "type": "string",
+                "description": "Plugin package name"
+              },
+              {
+                "type": "object",
+                "description": "Plugin factory options"
+              }
+            ],
+            "minItems": 2,
+            "maxItems": 2
+          }
+        ]
+      }
+    },
     "themes": {
       "type": "object",
       "description": "Color themes configuration. Use preset name or custom hex values.",

--- a/packages/flame/eslint.config.js
+++ b/packages/flame/eslint.config.js
@@ -36,6 +36,7 @@ export default tseslint.config(
       "react-hooks/gating": "off",
       "react-hooks/unsupported-syntax": "off",
       "react-hooks/incompatible-library": "off",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
       "perfectionist/sort-classes": ["error", { type: "natural", order: "asc" }],
     },
     settings: {
@@ -47,6 +48,13 @@ export default tseslint.config(
     files: [".docu/**/*.tsx"],
     rules: {
       "react/jsx-no-target-blank": "error",
+    },
+  },
+
+  {
+    files: [".docu/__tests__/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
     },
   },
 


### PR DESCRIPTION
- Create plugin interfaces and types (DocuBookPlugin, PluginBuilder, PageContext, PageMeta, DevServerContext)
- Implement BuildPluginBuilder with 10 registration + execution methods
- Add plugin-loader with specifier resolution and factory/simple patterns
- Wire full pipeline in build.ts (onStart -> onLoad -> transformFrontmatter -> injectHead/Body -> transformHtml -> onEnd)
- Wire handleRequest in server.ts with error isolation
- Add headExtra/bodyExtra injection points in html.ts
- Support remark/rehype plugin merging in mdx.ts
- Add plugins field to DocuConfig types and JSON Schema
- Include 75 unit/integration/loader/mdx/schema tests
- Refactor tests for DRY with shared helpers

Refs: #218