### PR TITLE
chore(flame): rename rawContent to resolvedContent in getDocsForSlug

### DIFF
--- a/packages/flame/.docu/node/server.ts
+++ b/packages/flame/.docu/node/server.ts
@@ -164,7 +164,7 @@ async function getDocsForSlug(slug: string) {
     frontmatter,
     tocs: result.tocs,
     filePath: relPath,
-    rawContent: content,
+    resolvedContent: content,
   };
 }
 
@@ -199,7 +199,7 @@ async function renderDocsServerPage(
       slug: slug.join("/") || "/",
       filePath: doc.filePath,
       frontmatter: doc.frontmatter,
-      content: doc.rawContent,
+      content: doc.resolvedContent,
       config: docuConfig,
     };
     const headExtra = builder.collectHead(ctx);


### PR DESCRIPTION
- Rename field rawContent → resolvedContent in getDocsForSlug() return
- Update consumer renderDocsServerPage() to use doc.resolvedContent
- No functional changes, only naming clarity