### PR TITLE
chore(packages): bump dependencies and fix prepublishOnly

### DIFF
--- a/.changeset/0cf4b0d7.md
+++ b/.changeset/0cf4b0d7.md
@@ -1,0 +1,9 @@
+---
+"@docubook/core": patch
+"@docubook/mdx-content": patch
+---
+
+chore: bump dependencies and fix prepublishOnly
+
+- **@docubook/core**: Upgrade TypeScript 5.9.3 → 6.0.3, tailwind-merge 2.6.1 → 3.6.0 (Tailwind v4 compatible, twMerge API unchanged), @types/react 19.2.8 → 19.2.17
+- **@docubook/mdx-content**: Upgrade TypeScript 5.9.3 → 6.0.3, react 19.2.3 → 19.2.7, react-dom 19.2.3 → 19.2.7, @types/react 19.2.8 → 19.2.17; remove redundant `clean` step from prepublishOnly script

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,14 +53,14 @@
     "rehype-prism-plus": "^2.0.2",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^2.6.1",
+    "tailwind-merge": "^3.6.0",
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.19.37",
-    "@types/react": "19.2.8",
+    "@types/react": "19.2.17",
     "@types/unist": "^3.0.3",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "unified": "^11.0.0"
   }
 }

--- a/packages/mdx-content/package.json
+++ b/packages/mdx-content/package.json
@@ -37,7 +37,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "prepublishOnly": "pnpm run clean && pnpm run build"
+    "prepublishOnly": "pnpm run build"
   },
   "keywords": [
     "docubook",
@@ -72,13 +72,13 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/react": "19.2.8",
+    "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "jsdom": "^29.1.1",
     "lucide-react": "^1.7.0",
-    "react": ">=18",
-    "react-dom": ">=18",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "react-icons": "^5.0.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,10 @@ overrides:
   flatted: ">=3.4.2"
   postcss: ">=8.5.10"
   esbuild: ">=0.28.1"
+  react: 19.2.7
+  react-dom: 19.2.7
+  "@types/react": 19.2.17
+  "@types/react-dom": 19.2.3
 
 importers:
   .:
@@ -47,7 +51,7 @@ importers:
         version: 16.4.0
       next:
         specifier: ^16.2.6
-        version: 16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       prettier:
         specifier: ^3.8.1
         version: 3.8.4
@@ -74,7 +78,7 @@ importers:
         version: 4.6.3
       "@docsearch/react":
         specifier: ^4.6.2
-        version: 4.6.3(@algolia/client-search@5.54.0)(@types/react@19.2.8)(algoliasearch@5.54.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)
+        version: 4.6.3(@algolia/client-search@5.54.0)(@types/react@19.2.17)(algoliasearch@5.54.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)
       "@docubook/core":
         specifier: workspace:*
         version: link:../../packages/core
@@ -83,31 +87,31 @@ importers:
         version: link:../../packages/mdx-content
       "@radix-ui/react-collapsible":
         specifier: ^1.1.12
-        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@radix-ui/react-dialog":
         specifier: ^1.1.15
-        version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@radix-ui/react-dropdown-menu":
         specifier: ^2.1.16
-        version: 2.1.17(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 2.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@radix-ui/react-popover":
         specifier: ^1.1.15
-        version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@radix-ui/react-scroll-area":
         specifier: ^1.2.10
-        version: 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@radix-ui/react-separator":
         specifier: ^1.1.8
-        version: 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@radix-ui/react-slot":
         specifier: ^1.2.4
-        version: 1.2.5(@types/react@19.2.8)(react@19.2.3)
+        version: 1.2.5(@types/react@19.2.17)(react@19.2.7)
       "@radix-ui/react-toggle":
         specifier: ^1.1.10
-        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@radix-ui/react-toggle-group":
         specifier: ^1.1.11
-        version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -116,28 +120,28 @@ importers:
         version: 2.1.1
       cmdk:
         specifier: ^1.1.1
-        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       geist:
         specifier: ^1.7.0
-        version: 1.7.2(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 1.7.2(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       lucide-react:
         specifier: ^1.7.0
-        version: 1.18.0(react@19.2.3)
+        version: 1.18.0(react@19.2.7)
       next:
         specifier: ^16.2.6
-        version: 16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: ^0.4.6
-        version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
-        specifier: 19.2.3
-        version: 19.2.3
+        specifier: 19.2.7
+        version: 19.2.7
       react-dom:
-        specifier: 19.2.3
-        version: 19.2.3(react@19.2.3)
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
       sonner:
         specifier: ^1.7.4
-        version: 1.7.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 1.7.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwind-merge:
         specifier: ^2.6.1
         version: 2.6.1
@@ -155,11 +159,11 @@ importers:
         specifier: ^20.19.37
         version: 20.19.43
       "@types/react":
-        specifier: 19.2.8
-        version: 19.2.8
+        specifier: 19.2.17
+        version: 19.2.17
       "@types/react-dom":
         specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.8)
+        version: 19.2.3(@types/react@19.2.17)
       "@types/unist":
         specifier: ^3.0.3
         version: 3.0.3
@@ -222,7 +226,7 @@ importers:
         version: 2.1.1
       next-mdx-remote:
         specifier: ^6.0.0
-        version: 6.0.0(@types/react@19.2.8)(react@19.2.3)
+        version: 6.0.0(@types/react@19.2.17)(react@19.2.7)
       rehype-autolink-headings:
         specifier: ^7.1.0
         version: 7.1.0
@@ -239,8 +243,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       tailwind-merge:
-        specifier: ^2.6.1
-        version: 2.6.1
+        specifier: ^3.6.0
+        version: 3.6.0
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
@@ -249,14 +253,14 @@ importers:
         specifier: ^20.19.37
         version: 20.19.43
       "@types/react":
-        specifier: 19.2.8
-        version: 19.2.8
+        specifier: 19.2.17
+        version: 19.2.17
       "@types/unist":
         specifier: ^3.0.3
         version: 3.0.3
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       unified:
         specifier: ^11.0.0
         version: 11.0.5
@@ -292,13 +296,13 @@ importers:
         version: 5.5.23
       lucide-react:
         specifier: ^1.14.0
-        version: 1.18.0(react@19.2.3)
+        version: 1.18.0(react@19.2.7)
       react:
-        specifier: ^19.0.0
-        version: 19.2.3
+        specifier: 19.2.7
+        version: 19.2.7
       react-dom:
-        specifier: ^19.0.0
-        version: 19.2.3(react@19.2.3)
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.1
@@ -307,11 +311,11 @@ importers:
         specifier: ^22.0.0
         version: 22.19.21
       "@types/react":
-        specifier: ^19.0.0
-        version: 19.2.8
+        specifier: 19.2.17
+        version: 19.2.17
       "@types/react-dom":
-        specifier: ^19.0.0
-        version: 19.2.3(@types/react@19.2.8)
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       autoprefixer:
         specifier: ^10.4.0
         version: 10.5.0(postcss@8.5.15)
@@ -347,38 +351,38 @@ importers:
     dependencies:
       "@docubook/core":
         specifier: ">=1.6.0"
-        version: 1.7.1(@types/react@19.2.8)(react@19.2.3)
+        version: 1.7.1(@types/react@19.2.17)(react@19.2.7)
     devDependencies:
       "@testing-library/jest-dom":
         specifier: ^6.9.1
         version: 6.9.1
       "@testing-library/react":
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@types/react":
-        specifier: 19.2.8
-        version: 19.2.8
+        specifier: 19.2.17
+        version: 19.2.17
       "@types/react-dom":
         specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.8)
+        version: 19.2.3(@types/react@19.2.17)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
       lucide-react:
         specifier: ^1.7.0
-        version: 1.18.0(react@19.2.3)
+        version: 1.18.0(react@19.2.7)
       react:
-        specifier: ">=18"
-        version: 19.2.3
+        specifier: 19.2.7
+        version: 19.2.7
       react-dom:
-        specifier: ">=18"
-        version: 19.2.3(react@19.2.3)
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
       react-icons:
         specifier: ^5.0.0
-        version: 5.6.0(react@19.2.3)
+        version: 5.6.0(react@19.2.7)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/themes-colors:
     devDependencies:
@@ -405,7 +409,7 @@ importers:
         version: 5.5.23
       lucide-react:
         specifier: ">=1.0.0"
-        version: 1.18.0(react@19.2.3)
+        version: 1.18.0(react@19.2.7)
       tailwind-merge:
         specifier: ^2.6.1
         version: 2.6.1
@@ -418,19 +422,19 @@ importers:
         version: 6.9.1
       "@testing-library/react":
         specifier: ^16.3.0
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@types/react":
-        specifier: ^19.2.0
-        version: 19.2.8
+        specifier: 19.2.17
+        version: 19.2.17
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
       react:
-        specifier: ^19.2.0
-        version: 19.2.3
+        specifier: 19.2.7
+        version: 19.2.7
       react-dom:
-        specifier: ^19.2.0
-        version: 19.2.3(react@19.2.3)
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
       tsup:
         specifier: ^8.5.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -1111,9 +1115,9 @@ packages:
         integrity: sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==,
       }
     peerDependencies:
-      "@types/react": ">= 16.8.0 < 20.0.0"
-      react: ">= 16.8.0 < 20.0.0"
-      react-dom: ">= 16.8.0 < 20.0.0"
+      "@types/react": 19.2.17
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -1134,9 +1138,9 @@ packages:
         integrity: sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==,
       }
     peerDependencies:
-      "@types/react": ">= 16.8.0 < 20.0.0"
-      react: ">= 16.8.0 < 20.0.0"
-      react-dom: ">= 16.8.0 < 20.0.0"
+      "@types/react": 19.2.17
+      react: 19.2.7
+      react-dom: 19.2.7
       search-insights: ">= 1 < 3"
     peerDependenciesMeta:
       "@types/react":
@@ -1554,8 +1558,8 @@ packages:
         integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==,
       }
     peerDependencies:
-      react: ">=16.8.0"
-      react-dom: ">=16.8.0"
+      react: 19.2.7
+      react-dom: 19.2.7
 
   "@floating-ui/utils@0.2.11":
     resolution:
@@ -1900,8 +1904,8 @@ packages:
         integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==,
       }
     peerDependencies:
-      "@types/react": ">=16"
-      react: ">=16"
+      "@types/react": 19.2.17
+      react: 19.2.7
 
   "@napi-rs/wasm-runtime@1.1.5":
     resolution:
@@ -2605,10 +2609,10 @@ packages:
         integrity: sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2621,10 +2625,10 @@ packages:
         integrity: sha512-F0s8+p2XNpfc3k02zBfB0jPWbkHVG162+p7BdUMyJ2308QMqZ+oaclX+FAzKFovgL5OqRU+Rvy6f/vbdlJVaqA==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2637,10 +2641,10 @@ packages:
         integrity: sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2653,8 +2657,8 @@ packages:
         integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2665,8 +2669,8 @@ packages:
         integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2677,10 +2681,10 @@ packages:
         integrity: sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2693,8 +2697,8 @@ packages:
         integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2705,10 +2709,10 @@ packages:
         integrity: sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2721,10 +2725,10 @@ packages:
         integrity: sha512-S6b3Jm57sY5EdDyOMLkacbB0qMnKhy1RCKZCt795ZkmtUOAvojYIZ5p7dXHIh5Cyr3jCLLI5/g64V3FKLudZmw==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2737,8 +2741,8 @@ packages:
         integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2749,10 +2753,10 @@ packages:
         integrity: sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2765,8 +2769,8 @@ packages:
         integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2777,10 +2781,10 @@ packages:
         integrity: sha512-fmbNnFyf+JYCN0DhhWnEdUTDnZD1mXaPQWivdsPIb8oOSbARfD3LIQJbLCG8a8QLCwoMxiJ7GVPIFcC8Dw8v2Q==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2793,10 +2797,10 @@ packages:
         integrity: sha512-8brVpAU5Uq7Bh0c8EFc4ZTf2JJTYn0o+1L+CUJB3UYIOkTjKGMgoHvduylrahdmNlr3DfH0rFq2DrbNZXgaspw==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2809,10 +2813,10 @@ packages:
         integrity: sha512-9PB589e1aWZbrlFUHdz6WiPCL+xLZHQFX7oibqG/6Q0SwOkxDyQX9W/cyPa+sAPPKuC8cpLCpRczE5a/1DiwVQ==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2825,10 +2829,10 @@ packages:
         integrity: sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2841,10 +2845,10 @@ packages:
         integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2857,10 +2861,10 @@ packages:
         integrity: sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2873,10 +2877,10 @@ packages:
         integrity: sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2889,10 +2893,10 @@ packages:
         integrity: sha512-DS39ziOgea75U/TrXKU2/oKp0be2jrDHnzFLvahg/0iNAT1Zq16e4Uw0WXwyXvsK+mG3BRyMb7A3NRZMDuEXtQ==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2905,10 +2909,10 @@ packages:
         integrity: sha512-gvgW+JV/Mbjj6darztTetnmElpQEzZrXpJvfj+dOxNAxiyHEAyUvEjjl4zxblvmjmKmi3jfPoy7ZdxzCuUBJSA==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2921,8 +2925,8 @@ packages:
         integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2933,10 +2937,10 @@ packages:
         integrity: sha512-TEgECgJaWGAHJJZGzNNEYTNBdIXqX7LchANycpyP7DkfjmuiSN7ISt1k/ZRGVJgVJonsgP4vwaiKMn5utrcwWQ==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2949,10 +2953,10 @@ packages:
         integrity: sha512-FikrKJemoBGZQ6uRID0HJqSPBP6D7OppdD2OhLl0ZYLlAyPXI7MezoYGmumwNkrAoRm35xXkb4C8JPfJZZzcaw==,
       }
     peerDependencies:
-      "@types/react": "*"
-      "@types/react-dom": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2965,8 +2969,8 @@ packages:
         integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2977,8 +2981,8 @@ packages:
         integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -2989,8 +2993,8 @@ packages:
         integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -3001,8 +3005,8 @@ packages:
         integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -3013,8 +3017,8 @@ packages:
         integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -3025,8 +3029,8 @@ packages:
         integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -3037,8 +3041,8 @@ packages:
         integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==,
       }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -3802,10 +3806,10 @@ packages:
     engines: { node: ">=18" }
     peerDependencies:
       "@testing-library/dom": ^10.0.0
-      "@types/react": ^18.0.0 || ^19.0.0
-      "@types/react-dom": ^18.0.0 || ^19.0.0
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3
+      react: 19.2.7
+      react-dom: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -4004,12 +4008,12 @@ packages:
         integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==,
       }
     peerDependencies:
-      "@types/react": ^19.2.0
+      "@types/react": 19.2.17
 
-  "@types/react@19.2.8":
+  "@types/react@19.2.17":
     resolution:
       {
-        integrity: sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==,
+        integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==,
       }
 
   "@types/shimmer@1.2.0":
@@ -4953,8 +4957,8 @@ packages:
         integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==,
       }
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^18 || ^19 || ^19.0.0-rc
+      react: 19.2.7
+      react-dom: 19.2.7
 
   collapse-white-space@2.1.0:
     resolution:
@@ -7100,7 +7104,7 @@ packages:
         integrity: sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA==,
       }
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: 19.2.7
 
   lz-string@1.5.0:
     resolution:
@@ -7602,7 +7606,7 @@ packages:
       }
     engines: { node: ">=14", npm: ">=7" }
     peerDependencies:
-      react: ">=16"
+      react: 19.2.7
 
   next-themes@0.4.6:
     resolution:
@@ -7610,8 +7614,8 @@ packages:
         integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==,
       }
     peerDependencies:
-      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react: 19.2.7
+      react-dom: 19.2.7
 
   next@16.2.9:
     resolution:
@@ -7624,8 +7628,8 @@ packages:
       "@opentelemetry/api": ^1.1.0
       "@playwright/test": ^1.51.1
       babel-plugin-react-compiler: "*"
-      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react: 19.2.7
+      react-dom: 19.2.7
       sass: ^1.3.0
     peerDependenciesMeta:
       "@opentelemetry/api":
@@ -8166,13 +8170,13 @@ packages:
         integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
       }
 
-  react-dom@19.2.3:
+  react-dom@19.2.7:
     resolution:
       {
-        integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==,
+        integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==,
       }
     peerDependencies:
-      react: ^19.2.3
+      react: 19.2.7
 
   react-icons@5.6.0:
     resolution:
@@ -8180,7 +8184,7 @@ packages:
         integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==,
       }
     peerDependencies:
-      react: "*"
+      react: 19.2.7
 
   react-is@16.13.1:
     resolution:
@@ -8201,8 +8205,8 @@ packages:
       }
     engines: { node: ">=10" }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -8214,8 +8218,8 @@ packages:
       }
     engines: { node: ">=10" }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -8227,16 +8231,16 @@ packages:
       }
     engines: { node: ">=10" }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
 
-  react@19.2.3:
+  react@19.2.7:
     resolution:
       {
-        integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==,
+        integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==,
       }
     engines: { node: ">=0.10.0" }
 
@@ -8662,8 +8666,8 @@ packages:
         integrity: sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==,
       }
     peerDependencies:
-      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: 19.2.7
+      react-dom: 19.2.7
 
   source-map-js@1.2.1:
     resolution:
@@ -8860,7 +8864,7 @@ packages:
     peerDependencies:
       "@babel/core": "*"
       babel-plugin-macros: "*"
-      react: ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      react: 19.2.7
     peerDependenciesMeta:
       "@babel/core":
         optional: true
@@ -8899,6 +8903,12 @@ packages:
     resolution:
       {
         integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==,
+      }
+
+  tailwind-merge@3.6.0:
+    resolution:
+      {
+        integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==,
       }
 
   tailwindcss@4.3.0:
@@ -9182,6 +9192,14 @@ packages:
     engines: { node: ">=14.17" }
     hasBin: true
 
+  typescript@6.0.3:
+    resolution:
+      {
+        integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==,
+      }
+    engines: { node: ">=14.17" }
+    hasBin: true
+
   ufo@1.6.4:
     resolution:
       {
@@ -9309,8 +9327,8 @@ packages:
       }
     engines: { node: ">=10" }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -9322,8 +9340,8 @@ packages:
       }
     engines: { node: ">=10" }
     peerDependencies:
-      "@types/react": "*"
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      "@types/react": 19.2.17
+      react: 19.2.7
     peerDependenciesMeta:
       "@types/react":
         optional: true
@@ -10263,33 +10281,33 @@ snapshots:
 
   "@csstools/css-tokenizer@4.0.0": {}
 
-  "@docsearch/core@4.6.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@docsearch/core@4.6.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     optionalDependencies:
-      "@types/react": 19.2.8
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@types/react": 19.2.17
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   "@docsearch/css@4.6.3": {}
 
-  "@docsearch/react@4.6.3(@algolia/client-search@5.54.0)(@types/react@19.2.8)(algoliasearch@5.54.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(search-insights@2.17.3)":
+  "@docsearch/react@4.6.3(@algolia/client-search@5.54.0)(@types/react@19.2.17)(algoliasearch@5.54.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)":
     dependencies:
       "@algolia/autocomplete-core": 1.19.2(@algolia/client-search@5.54.0)(algoliasearch@5.54.0)(search-insights@2.17.3)
-      "@docsearch/core": 4.6.3(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      "@docsearch/core": 4.6.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       "@docsearch/css": 4.6.3
     optionalDependencies:
-      "@types/react": 19.2.8
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@types/react": 19.2.17
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - "@algolia/client-search"
       - algoliasearch
 
-  "@docubook/core@1.7.1(@types/react@19.2.8)(react@19.2.3)":
+  "@docubook/core@1.7.1(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
       "@11ty/gray-matter": 2.0.2
       clsx: 2.1.1
-      next-mdx-remote: 6.0.0(@types/react@19.2.8)(react@19.2.3)
+      next-mdx-remote: 6.0.0(@types/react@19.2.17)(react@19.2.7)
       rehype-autolink-headings: 7.1.0
       rehype-code-titles: 1.2.1
       rehype-prism-plus: 2.0.2
@@ -10490,11 +10508,11 @@ snapshots:
       "@floating-ui/core": 1.7.5
       "@floating-ui/utils": 0.2.11
 
-  "@floating-ui/react-dom@2.1.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@floating-ui/react-dom@2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
       "@floating-ui/dom": 1.7.6
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   "@floating-ui/utils@0.2.11": {}
 
@@ -10687,11 +10705,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@mdx-js/react@3.1.1(@types/react@19.2.8)(react@19.2.3)":
+  "@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
       "@types/mdx": 2.0.14
-      "@types/react": 19.2.8
-      react: 19.2.3
+      "@types/react": 19.2.17
+      react: 19.2.7
 
   "@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
     dependencies:
@@ -11107,353 +11125,353 @@ snapshots:
 
   "@radix-ui/primitive@1.1.4": {}
 
-  "@radix-ui/react-arrow@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-arrow@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-collapsible@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-collapsible@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
       "@radix-ui/primitive": 1.1.4
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-context": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-id": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-presence": 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-context": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-id": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-presence": 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-collection@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-collection@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-context": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-slot": 1.2.5(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-context": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-slot": 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.8)(react@19.2.3)":
+  "@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
-      react: 19.2.3
+      react: 19.2.7
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  "@radix-ui/react-context@1.1.4(@types/react@19.2.8)(react@19.2.3)":
+  "@radix-ui/react-context@1.1.4(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
-      react: 19.2.3
+      react: 19.2.7
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  "@radix-ui/react-dialog@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-dialog@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
       "@radix-ui/primitive": 1.1.4
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-context": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-dismissable-layer": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-focus-guards": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-focus-scope": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-id": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-portal": 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-presence": 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-slot": 1.2.5(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.8)(react@19.2.3)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-context": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-dismissable-layer": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-focus-guards": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-focus-scope": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-id": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-portal": 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-presence": 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-slot": 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.17)(react@19.2.7)
       aria-hidden: 1.2.6
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-remove-scroll: 2.7.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-direction@1.1.2(@types/react@19.2.8)(react@19.2.3)":
+  "@radix-ui/react-direction@1.1.2(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
-      react: 19.2.3
+      react: 19.2.7
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  "@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
-    dependencies:
-      "@radix-ui/primitive": 1.1.4
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-use-escape-keydown": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
-
-  "@radix-ui/react-dropdown-menu@2.1.17(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
       "@radix-ui/primitive": 1.1.4
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-context": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-id": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-menu": 2.1.17(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-use-escape-keydown": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.8)(react@19.2.3)":
-    dependencies:
-      react: 19.2.3
-    optionalDependencies:
-      "@types/react": 19.2.8
-
-  "@radix-ui/react-focus-scope@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
-    dependencies:
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
-
-  "@radix-ui/react-id@1.1.2(@types/react@19.2.8)(react@19.2.3)":
-    dependencies:
-      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-    optionalDependencies:
-      "@types/react": 19.2.8
-
-  "@radix-ui/react-menu@2.1.17(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-dropdown-menu@2.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
       "@radix-ui/primitive": 1.1.4
-      "@radix-ui/react-collection": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-context": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-direction": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-dismissable-layer": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-focus-guards": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-focus-scope": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-id": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-popper": 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-portal": 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-presence": 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-roving-focus": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-slot": 1.2.5(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-context": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-id": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-menu": 2.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
+
+  "@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.17)(react@19.2.7)":
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      "@types/react": 19.2.17
+
+  "@radix-ui/react-focus-scope@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+    dependencies:
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
+
+  "@radix-ui/react-id@1.1.2(@types/react@19.2.17)(react@19.2.7)":
+    dependencies:
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      "@types/react": 19.2.17
+
+  "@radix-ui/react-menu@2.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.4
+      "@radix-ui/react-collection": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-context": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-direction": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-dismissable-layer": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-focus-guards": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-focus-scope": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-id": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-popper": 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-portal": 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-presence": 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-roving-focus": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-slot": 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.17)(react@19.2.7)
       aria-hidden: 1.2.6
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-remove-scroll: 2.7.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-popover@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-popover@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
       "@radix-ui/primitive": 1.1.4
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-context": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-dismissable-layer": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-focus-guards": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-focus-scope": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-id": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-popper": 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-portal": 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-presence": 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-slot": 1.2.5(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.8)(react@19.2.3)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-context": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-dismissable-layer": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-focus-guards": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-focus-scope": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-id": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-popper": 1.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-portal": 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-presence": 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-slot": 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.17)(react@19.2.7)
       aria-hidden: 1.2.6
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-remove-scroll: 2.7.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-popper@1.3.0(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-popper@1.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
-      "@floating-ui/react-dom": 2.1.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-arrow": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-context": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-use-rect": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-use-size": 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      "@floating-ui/react-dom": 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-arrow": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-context": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-use-rect": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-use-size": 1.1.2(@types/react@19.2.17)(react@19.2.7)
       "@radix-ui/rect": 1.1.2
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-portal@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-portal@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
-      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-primitive@2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-primitive@2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
-      "@radix-ui/react-slot": 1.2.5(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-slot": 1.2.5(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-roving-focus@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-roving-focus@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
       "@radix-ui/primitive": 1.1.4
-      "@radix-ui/react-collection": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-context": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-direction": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-id": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-collection": 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-context": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-direction": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-id": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-scroll-area@1.2.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-scroll-area@1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
       "@radix-ui/number": 1.1.2
       "@radix-ui/primitive": 1.1.4
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-context": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-direction": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-presence": 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-context": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-direction": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-presence": 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-separator@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-separator@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-slot@1.2.5(@types/react@19.2.8)(react@19.2.3)":
+  "@radix-ui/react-slot@1.2.5(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  "@radix-ui/react-toggle-group@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
-    dependencies:
-      "@radix-ui/primitive": 1.1.4
-      "@radix-ui/react-context": 1.1.4(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-direction": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-roving-focus": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-toggle": 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
-
-  "@radix-ui/react-toggle@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@radix-ui/react-toggle-group@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
       "@radix-ui/primitive": 1.1.4
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-context": 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-direction": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-roving-focus": 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-toggle": 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.8)(react@19.2.3)":
+  "@radix-ui/react-toggle@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
-      react: 19.2.3
+      "@radix-ui/primitive": 1.1.4
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-use-controllable-state": 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
-  "@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.8)(react@19.2.3)":
+  "@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
-      "@radix-ui/react-use-effect-event": 0.0.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      react: 19.2.7
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  "@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.8)(react@19.2.3)":
+  "@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
-      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      "@radix-ui/react-use-effect-event": 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  "@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.8)(react@19.2.3)":
+  "@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
-      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  "@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.8)(react@19.2.3)":
+  "@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
-      react: 19.2.3
+      "@radix-ui/react-use-callback-ref": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  "@radix-ui/react-use-rect@1.1.2(@types/react@19.2.8)(react@19.2.3)":
+  "@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.17)(react@19.2.7)":
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      "@types/react": 19.2.17
+
+  "@radix-ui/react-use-rect@1.1.2(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
       "@radix-ui/rect": 1.1.2
-      react: 19.2.3
+      react: 19.2.7
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  "@radix-ui/react-use-size@1.1.2(@types/react@19.2.8)(react@19.2.3)":
+  "@radix-ui/react-use-size@1.1.2(@types/react@19.2.17)(react@19.2.7)":
     dependencies:
-      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      "@radix-ui/react-use-layout-effect": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
   "@radix-ui/rect@1.1.2": {}
 
@@ -11841,15 +11859,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  "@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
     dependencies:
       "@babel/runtime": 7.29.7
       "@testing-library/dom": 10.4.1
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
-      "@types/react-dom": 19.2.3(@types/react@19.2.8)
+      "@types/react": 19.2.17
+      "@types/react-dom": 19.2.3(@types/react@19.2.17)
 
   "@turbo/darwin-64@2.9.18":
     optional: true
@@ -11945,11 +11963,11 @@ snapshots:
 
   "@types/prismjs@1.26.6": {}
 
-  "@types/react-dom@19.2.3(@types/react@19.2.8)":
+  "@types/react-dom@19.2.3(@types/react@19.2.17)":
     dependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  "@types/react@19.2.8":
+  "@types/react@19.2.17":
     dependencies:
       csstype: 3.2.3
 
@@ -12582,14 +12600,14 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-dialog": 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      "@radix-ui/react-id": 1.1.2(@types/react@19.2.8)(react@19.2.3)
-      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      "@radix-ui/react-compose-refs": 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-dialog": 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@radix-ui/react-id": 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      "@radix-ui/react-primitive": 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
       - "@types/react"
       - "@types/react-dom"
@@ -12973,7 +12991,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -13006,7 +13024,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -13021,7 +13039,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       "@rtsao/scc": 1.1.0
       array-includes: 3.1.9
@@ -13413,9 +13431,9 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geist@1.7.2(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
+  geist@1.7.2(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
     dependencies:
-      next: 16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   generator-function@2.0.1: {}
 
@@ -14101,9 +14119,9 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@1.18.0(react@19.2.3):
+  lucide-react@1.18.0(react@19.2.7):
     dependencies:
-      react: 19.2.3
+      react: 19.2.7
 
   lz-string@1.5.0: {}
 
@@ -14616,12 +14634,12 @@ snapshots:
 
   natural-orderby@5.0.0: {}
 
-  next-mdx-remote@6.0.0(@types/react@19.2.8)(react@19.2.3):
+  next-mdx-remote@6.0.0(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       "@babel/code-frame": 7.29.7
       "@mdx-js/mdx": 3.1.1
-      "@mdx-js/react": 3.1.1(@types/react@19.2.8)(react@19.2.3)
-      react: 19.2.3
+      "@mdx-js/react": 3.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
       unist-util-remove: 4.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
@@ -14630,21 +14648,21 @@ snapshots:
       - "@types/react"
       - supports-color
 
-  next-themes@0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next-themes@0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
-  next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       "@next/env": 16.2.9
       "@swc/helpers": 0.5.15
       baseline-browser-mapping: 2.10.37
       caniuse-lite: 1.0.30001799
       postcss: 8.5.15
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(react@19.2.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
       "@next/swc-darwin-arm64": 16.2.9
       "@next/swc-darwin-x64": 16.2.9
@@ -14919,47 +14937,47 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-dom@19.2.3(react@19.2.3):
+  react-dom@19.2.7(react@19.2.7):
     dependencies:
-      react: 19.2.3
+      react: 19.2.7
       scheduler: 0.27.0
 
-  react-icons@5.6.0(react@19.2.3):
+  react-icons@5.6.0(react@19.2.7):
     dependencies:
-      react: 19.2.3
+      react: 19.2.7
 
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.8)(react@19.2.3):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
-      react: 19.2.3
-      react-style-singleton: 2.2.3(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.7
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
       tslib: 2.8.1
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  react-remove-scroll@2.7.2(@types/react@19.2.8)(react@19.2.3):
+  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.7):
     dependencies:
-      react: 19.2.3
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.8)(react@19.2.3)
-      react-style-singleton: 2.2.3(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.7
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.7)
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.8)(react@19.2.3)
-      use-sidecar: 1.1.3(@types/react@19.2.8)(react@19.2.3)
+      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.7)
+      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  react-style-singleton@2.2.3(@types/react@19.2.8)(react@19.2.3):
+  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.2.3
+      react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  react@19.2.3: {}
+  react@19.2.7: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -15361,10 +15379,10 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  sonner@1.7.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  sonner@1.7.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   source-map-js@1.2.1: {}
 
@@ -15491,10 +15509,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.3):
+  styled-jsx@5.1.6(react@19.2.7):
     dependencies:
       client-only: 0.0.1
-      react: 19.2.3
+      react: 19.2.7
 
   sucrase@3.35.1:
     dependencies:
@@ -15515,6 +15533,8 @@ snapshots:
   symbol-tree@3.2.4: {}
 
   tailwind-merge@2.6.1: {}
+
+  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.0: {}
 
@@ -15708,6 +15728,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  typescript@6.0.3: {}
+
   ufo@1.6.4: {}
 
   unbox-primitive@1.1.0:
@@ -15817,20 +15839,20 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-callback-ref@1.3.3(@types/react@19.2.8)(react@19.2.3):
+  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
-      react: 19.2.3
+      react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
-  use-sidecar@1.1.3(@types/react@19.2.8)(react@19.2.3):
+  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.2.3
+      react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
-      "@types/react": 19.2.8
+      "@types/react": 19.2.17
 
   util-deprecate@1.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,10 @@ overrides:
   flatted: ">=3.4.2"
   postcss: ">=8.5.10"
   esbuild: ">=0.28.1"
+  react: "19.2.7"
+  react-dom: "19.2.7"
+  "@types/react": "19.2.17"
+  "@types/react-dom": "19.2.3"
 allowBuilds:
   "@parcel/watcher": true
   bun: true


### PR DESCRIPTION
- @docubook/core: TypeScript 5.9.3→6.0.3, tailwind-merge 2.6.1→3.6.0, @types/react 19.2.8→19.2.17
- @docubook/mdx-content: TypeScript 5.9.3→6.0.3, react 19.2.3→19.2.7, react-dom 19.2.3→19.2.7, @types/react 19.2.8→19.2.17
- @docubook/mdx-content: remove redundant clean step from prepublishOnly script