### PR TITLE
fix(ci): update lockfile after changeset version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "turbo clean",
     "typecheck": "turbo typecheck",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && pnpm install --no-frozen-lockfile",
     "publish-packages": "pnpm build && changeset publish",
     "prepare": "husky",
     "commit": "czg"


### PR DESCRIPTION
Fix Release workflow: `version-packages` sekarang jadi `changeset version && pnpm install --no-frozen-lockfile` agar lockfile selalu sinkron setelah version bump.

**Root cause:** `changeset version` update peer dep `@docubook/core` (via `updateInternalDependencies: patch`), tapi lockfile tidak ikut diupdate. Di CI pnpm auto-enable `--frozen-lockfile`, jadi perlu `--no-frozen-lockfile` eksplisit.