### PR TITLE
fix(ci): remove pnpm install from version-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "turbo clean",
     "typecheck": "turbo typecheck",
     "changeset": "changeset",
-    "version-packages": "changeset version && pnpm install --no-frozen-lockfile",
+    "version-packages": "changeset version",
     "publish-packages": "pnpm build && changeset publish",
     "prepare": "husky",
     "commit": "czg"


### PR DESCRIPTION
## Problem

`version-packages` script: `changeset version && pnpm install --no-frozen-lockfile` gagal karena:

1. `changeset version` bump peer dep `@docubook/core` dari `>=1.6.0` ke `>=1.7.2`
2. `pnpm install --no-frozen-lockfile` coba resolve `@docubook/core@>=1.7.2` dari npm
3. Versi `1.7.2` belum dipublish — gagal

## Fix

Kembalikan `version-packages` ke `changeset version` saja, seperti aslinya. Tidak perlu `pnpm install` karena:

- Setup workflow sudah install dependencies (`pnpm install --frozen-lockfile`)
- `changeset version` hanya update file (package.json, CHANGELOG)
- Git commit oleh changesets action tidak butuh lockfile sinkron
- `publish-packages` (`pnpm build && changeset publish`) pake node_modules yang sudah ada

## Related

Reverts PR #228 yang salah.