### PR TITLE
fix(ci): skip husky during changeset version commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: "0"


### PR DESCRIPTION
## Problem

Release workflow gagal di pre-commit hook setelah `changeset version`:

1. ✅ `changeset version` sukses update package.json (bump peer dep)
2. ✅ `git add .`
3. ❌ `git commit` trigger pre-commit hook → `pnpm lint-staged`
4. Di CI, pnpm auto-enable `--frozen-lockfile` → deteksi lockfile mismatch dengan package.json baru
5. Gagal: `[ERR_PNPM_OUTDATED_LOCKFILE]`

## Fix

Set `HUSKY: "0"` di env step `changesets/action`. Ini skip semua husky hooks (pre-commit, commit-msg) selama proses release, karena:

- Lockfile akan selalu stale setelah `changeset version` mengupdate peer dep
- Tidak ada gunanya menjalankan lint-staged untuk commit otomatis ini
- Check kualitas kode sudah dijalankan di CI workflow terpisah