### PR TITLE
fix(flame): resolve React SSR hook error and switch to relative asset paths

### DIFF
--- a/.changeset/humman-no-distraction.md
+++ b/.changeset/humman-no-distraction.md
@@ -1,0 +1,45 @@
+---
+"@docubook/flame": patch
+---
+
+fix(html.ts): depth-aware relative asset paths for subfolder/static hosting
+
+- Add `depth` option to `HtmlShellOptions` interface and `htmlShell()` (default 0)
+- Compute `depthPrefix` and `assetPrefix` based on depth: `""` at root, `"../".repeat(depth)` for subdirs
+- Add `resolvePath()` helper to convert absolute paths (starting with `/`) to relative using depth prefix
+- Change CSS `<link>` href from `"/assets/${css}"` to `"${assetPrefix + css}"`
+- Change JS `<script>` src from `"/assets/${js}"` to `"${assetPrefix + js}"`
+- Change favicon `<link>` href from raw value to `resolvePath(favicon)` with conditional rendering (skip when empty)
+- Favicon fallback updated from `/favicon.ico` to `/docs/assets/images/favicon.ico` to match template scaffold location
+
+fix(build.ts): calculate and pass page depth to htmlShell
+
+- Compute `depth = slug.split("/").length` for docs pages, default `1` for index page
+- Pass `depth` to `htmlShell()` call in `renderDocsPage()`
+- Update favicon fallback for landing and 404 pages to `/docs/assets/images/favicon.ico`
+
+fix(Lucide.tsx): resolve TypeScript error with lucide-react Icon type
+
+- Add `as unknown as` intermediate cast for `LucideIcons` index access to satisfy stricter lucide-react 1.18 types
+
+fix(Search.tsx): correct Kbd size prop value
+
+- Change `size="s"` to `size="sm"` across 3 occurrences (KbdSize = `"xs" | "sm" | "md" | "lg" | "xl"`)
+
+fix(plugin.ts): add missing DocuConfig type re-export
+
+- Add `export type { DocuConfig }` so `plugin-builder.ts` can import it from `./plugin`
+
+fix(server-routes.ts): align inlineThemeCss field type
+
+- Change `inlineThemeCss: string` to `inlineThemeCss?: string` to match `computeInlineThemeCss()` return type
+
+fix(server.ts): add non-null assertions for DevServerContext
+
+- Add `server.port!` and `server.hostname!` since bun-types 1.3.14 defines these as `number | undefined` / `string | undefined`
+
+fix(package.json): add unified dependency and align react version
+
+- Add `"unified": "^11.0.0"` as direct dependency (was previously only a transitive dependency)
+- Bump `react` from `^19.0.0` to `^19.2.7` for consistent resolution with @docubook/ui-react
+- Bump `react-dom` from `^19.0.0` to `^19.2.7`

--- a/packages/flame/.docu/__tests__/html.test.ts
+++ b/packages/flame/.docu/__tests__/html.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import { htmlShell } from "../node/html";
+
+const MINIMAL_OPTS = {
+  title: "Test",
+  description: "A test page",
+  body: "<p>hello</p>",
+  favicon: "/favicon.ico",
+  css: "client-abc123.css",
+  js: "client-xyz789.js",
+};
+
+describe("htmlShell", () => {
+  describe("depth and relative paths", () => {
+    it("uses 'assets/' prefix at root (depth=0 default)", () => {
+      const html = htmlShell(MINIMAL_OPTS);
+      expect(html).toContain('href="assets/client-abc123.css"');
+      expect(html).toContain('src="assets/client-xyz789.js"');
+    });
+
+    it("uses '../assets/' prefix at depth=1", () => {
+      const html = htmlShell({ ...MINIMAL_OPTS, depth: 1 });
+      expect(html).toContain('href="../assets/client-abc123.css"');
+      expect(html).toContain('src="../assets/client-xyz789.js"');
+    });
+
+    it("uses '../../assets/' prefix at depth=2", () => {
+      const html = htmlShell({ ...MINIMAL_OPTS, depth: 2 });
+      expect(html).toContain('href="../../assets/client-abc123.css"');
+      expect(html).toContain('src="../../assets/client-xyz789.js"');
+    });
+
+    it("uses '../../../assets/' prefix at depth=3", () => {
+      const html = htmlShell({ ...MINIMAL_OPTS, depth: 3 });
+      expect(html).toContain('href="../../../assets/client-abc123.css"');
+      expect(html).toContain('src="../../../assets/client-xyz789.js"');
+    });
+  });
+
+  describe("resolvePath for favicon", () => {
+    it("resolves absolute favicon path at root (depth=0)", () => {
+      const html = htmlShell({
+        ...MINIMAL_OPTS,
+        favicon: "/docs/assets/images/favicon.ico",
+      });
+      expect(html).toContain('href="docs/assets/images/favicon.ico"');
+    });
+
+    it("resolves absolute favicon path at depth=1", () => {
+      const html = htmlShell({
+        ...MINIMAL_OPTS,
+        favicon: "/docs/assets/images/favicon.ico",
+        depth: 1,
+      });
+      expect(html).toContain('href="../docs/assets/images/favicon.ico"');
+    });
+
+    it("resolves absolute favicon path at depth=2", () => {
+      const html = htmlShell({
+        ...MINIMAL_OPTS,
+        favicon: "/docs/assets/images/favicon.ico",
+        depth: 2,
+      });
+      expect(html).toContain('href="../../docs/assets/images/favicon.ico"');
+    });
+
+    it("leaves relative favicon path unchanged", () => {
+      const html = htmlShell({
+        ...MINIMAL_OPTS,
+        favicon: "favicon.ico",
+      });
+      expect(html).toContain('href="favicon.ico"');
+    });
+
+    it("omits favicon link when favicon is empty string", () => {
+      const html = htmlShell({
+        ...MINIMAL_OPTS,
+        favicon: "",
+      });
+      expect(html).not.toContain('rel="icon"');
+    });
+  });
+
+  describe("basic structure", () => {
+    it("renders DOCTYPE and html tag", () => {
+      const html = htmlShell(MINIMAL_OPTS);
+      expect(html).toMatch(/^<!DOCTYPE html>\n<html/);
+    });
+
+    it("includes title and description", () => {
+      const html = htmlShell(MINIMAL_OPTS);
+      expect(html).toContain("<title>Test</title>");
+      expect(html).toContain('content="A test page"');
+    });
+
+    it("renders body content", () => {
+      const html = htmlShell(MINIMAL_OPTS);
+      expect(html).toContain('<div id="root"><p>hello</p></div>');
+    });
+  });
+
+  describe("nonce", () => {
+    it("adds nonce attribute to script tags when provided", () => {
+      const html = htmlShell({ ...MINIMAL_OPTS, nonce: "abc123" });
+      expect(html).toContain('nonce="abc123"');
+    });
+
+    it("does not include nonce attribute when omitted", () => {
+      const html = htmlShell(MINIMAL_OPTS);
+      expect(html).not.toContain("nonce=");
+    });
+  });
+
+  describe("CSP", () => {
+    it("injects CSP meta tag when provided", () => {
+      const html = htmlShell({ ...MINIMAL_OPTS, csp: "default-src 'self'" });
+      expect(html).toContain('<meta http-equiv="Content-Security-Policy"');
+      expect(html).toContain("default-src");
+      expect(html).toContain("&#39;self&#39;");
+    });
+
+    it("omits CSP meta tag when not provided", () => {
+      const html = htmlShell(MINIMAL_OPTS);
+      expect(html).not.toContain("Content-Security-Policy");
+    });
+  });
+
+  describe("theme CSS", () => {
+    it("injects theme style tag when provided", () => {
+      const html = htmlShell({ ...MINIMAL_OPTS, themeCss: "body{color:red}" });
+      expect(html).toContain("<style");
+      expect(html).toContain("body{color:red}");
+    });
+
+    it("omits theme style when not provided", () => {
+      const html = htmlShell(MINIMAL_OPTS);
+      expect(html).not.toContain("<style");
+    });
+  });
+
+  describe("plugin injections", () => {
+    it("injects headExtra before closing head", () => {
+      const html = htmlShell({
+        ...MINIMAL_OPTS,
+        headExtra: ['<meta name="foo" content="bar">'],
+      });
+      expect(html).toContain('<meta name="foo" content="bar">');
+    });
+
+    it("injects bodyExtra before closing body", () => {
+      const html = htmlShell({
+        ...MINIMAL_OPTS,
+        bodyExtra: ['<div id="custom">extra</div>'],
+      });
+      expect(html).toContain('<div id="custom">extra</div>');
+    });
+
+    it("injects multiple headExtra items", () => {
+      const html = htmlShell({
+        ...MINIMAL_OPTS,
+        headExtra: ['<meta name="a">', '<meta name="b">'],
+      });
+      expect(html).toContain('<meta name="a">');
+      expect(html).toContain('<meta name="b">');
+    });
+  });
+
+  describe("extraScripts", () => {
+    it("injects extraScripts when provided", () => {
+      const html = htmlShell({
+        ...MINIMAL_OPTS,
+        extraScripts: '<script>console.log("extra")</script>',
+      });
+      expect(html).toContain('console.log("extra")');
+    });
+  });
+
+  describe("XSS safety (Bun.escapeHTML)", () => {
+    it("escapes title/description with special chars", () => {
+      const html = htmlShell({
+        ...MINIMAL_OPTS,
+        title: 'Test & "Hello" <World>',
+        description: "Foo & Bar",
+      });
+      expect(html).toContain("Test &amp; &quot;Hello&quot; &lt;World&gt;");
+      expect(html).toContain("Foo &amp; Bar");
+    });
+  });
+});

--- a/packages/flame/.docu/components/Lucide.tsx
+++ b/packages/flame/.docu/components/Lucide.tsx
@@ -7,7 +7,7 @@ import type { LucideIcon } from "lucide-react";
  */
 export function getLucideIcon(name: string): LucideIcon | null {
   if (!name) return null;
-  const icon = (LucideIcons as Record<string, LucideIcon | undefined>)[name];
+  const icon = (LucideIcons as unknown as Record<string, LucideIcon | undefined>)[name];
   return icon || null;
 }
 

--- a/packages/flame/.docu/components/Search.tsx
+++ b/packages/flame/.docu/components/Search.tsx
@@ -212,16 +212,16 @@ export default function Search({ className }: SearchProps) {
 
           <div className="border-base-300 hidden items-center gap-3 border-t px-4 py-2.5 md:flex">
             <div className="flex items-center gap-1">
-              <Kbd size="s">
+              <Kbd size="sm">
                 <FnKey.Down />
               </Kbd>
-              <Kbd size="s">
+              <Kbd size="sm">
                 <FnKey.Up />
               </Kbd>
               <span className="text-base-content/50 text-xs">navigate</span>
             </div>
             <div className="flex items-center gap-1">
-              <Kbd size="s">
+              <Kbd size="sm">
                 <CornerDownLeft className="h-3 w-3" />
               </Kbd>
               <span className="text-base-content/50 text-xs">select</span>

--- a/packages/flame/.docu/node/build.ts
+++ b/packages/flame/.docu/node/build.ts
@@ -138,7 +138,8 @@ async function renderDocsPage(
   const headExtra = builder?.collectHead(ctx);
   const bodyExtra = builder?.collectBody(ctx);
 
-  const favicon = docuConfig.meta?.favicon || "/favicon.ico";
+  const depth = slug ? slug.split("/").length : 1;
+  const favicon = docuConfig.meta?.favicon || "/docs/assets/images/favicon.ico";
   let html = htmlShell({
     title,
     description,
@@ -148,6 +149,7 @@ async function renderDocsPage(
     js: assetManifest.js,
     nonce,
     themeCss: inlineThemeCss,
+    depth,
     headExtra,
     bodyExtra,
   });
@@ -332,7 +334,7 @@ async function build() {
   }
 
   const landingPage = React.createElement(IndexPage);
-  const landingFavicon = docuConfig.meta?.favicon || "/favicon.ico";
+  const landingFavicon = docuConfig.meta?.favicon || "/docs/assets/images/favicon.ico";
   const landingHtml = htmlShell({
     title: docuConfig.meta?.title || "DocuBook",
     description: docuConfig.meta?.description || "",
@@ -350,7 +352,7 @@ async function build() {
     { repoUrl: docuConfig.repo?.url },
     React.createElement(NotFoundPage)
   );
-  const notFoundFavicon = docuConfig.meta?.favicon || "/favicon.ico";
+  const notFoundFavicon = docuConfig.meta?.favicon || "/docs/assets/images/favicon.ico";
   const notFoundHtml = htmlShell({
     title: "404 - Not Found",
     description: "",

--- a/packages/flame/.docu/node/html.ts
+++ b/packages/flame/.docu/node/html.ts
@@ -14,6 +14,8 @@ export interface HtmlShellOptions {
   csp?: string;
   extraScripts?: string;
   themeCss?: string;
+  /** Depth from document root (0=root, 1=subdir, 2=sub/subdir). Used for relative asset paths. */
+  depth?: number;
   /** HTML strings to inject before `</head>` (from plugin `injectHead` hooks). */
   headExtra?: string[];
   /** HTML strings to inject before `</body>`, after the main script (from plugin `injectBody` hooks). */
@@ -32,6 +34,7 @@ export function htmlShell(opts: HtmlShellOptions): string {
     csp,
     extraScripts,
     themeCss,
+    depth = 0,
     headExtra,
     bodyExtra,
   } = opts;
@@ -39,6 +42,9 @@ export function htmlShell(opts: HtmlShellOptions): string {
   const themeStyle = themeCss ? `\n  <style${nonceAttr}>${Bun.escapeHTML(themeCss)}</style>` : "";
   const headInjection = headExtra?.length ? `\n  ${headExtra.join("\n  ")}` : "";
   const bodyInjection = bodyExtra?.length ? `\n  ${bodyExtra.join("\n  ")}` : "";
+  const depthPrefix = depth === 0 ? "" : "../".repeat(depth);
+  const assetPrefix = depthPrefix + "assets/";
+  const resolvePath = (path: string) => (path.startsWith("/") ? depthPrefix + path.slice(1) : path);
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -46,14 +52,14 @@ export function htmlShell(opts: HtmlShellOptions): string {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${Bun.escapeHTML(title)}</title>
   <meta name="description" content="${Bun.escapeHTML(description)}">
-  <link rel="icon" type="image/x-icon" href="${Bun.escapeHTML(favicon)}">${themeStyle}
-  <link rel="stylesheet" href="/assets/${Bun.escapeHTML(css)}">
+  ${favicon ? `<link rel="icon" type="image/x-icon" href="${Bun.escapeHTML(resolvePath(favicon))}">` : ""}${themeStyle}
+  <link rel="stylesheet" href="${Bun.escapeHTML(assetPrefix + css)}">
   ${csp ? `<meta http-equiv="Content-Security-Policy" content="${Bun.escapeHTML(csp)}">` : ""}
   <script${nonceAttr}>try{if(localStorage.getItem("theme")==="dark")document.documentElement.classList.add("dark")}catch(e){}</script>${headInjection}
 </head>
 <body>
   <div id="root">${body}</div>
-  <script${nonceAttr} src="/assets/${Bun.escapeHTML(js)}"></script>${extraScripts ? `\n  ${extraScripts}` : ""}${bodyInjection}
+  <script${nonceAttr} src="${Bun.escapeHTML(assetPrefix + js)}"></script>${extraScripts ? `\n  ${extraScripts}` : ""}${bodyInjection}
 </body>
 </html>`;
 }

--- a/packages/flame/.docu/node/plugin.ts
+++ b/packages/flame/.docu/node/plugin.ts
@@ -55,6 +55,8 @@ export interface DevServerContext {
   hostname: string;
 }
 
+export type { DocuConfig };
+
 // ─── PluginBuilder Interface ────────────────────────────
 
 /**

--- a/packages/flame/.docu/node/server-routes.ts
+++ b/packages/flame/.docu/node/server-routes.ts
@@ -19,7 +19,7 @@ import { htmlShell as createHtmlShell, hmrScript, errorHtml } from "./html";
 export interface ServerState {
   docuConfig: DocuConfig;
   assetManifest: { css: string; js: string };
-  inlineThemeCss: string;
+  inlineThemeCss?: string;
   builder: BuildPluginBuilder | null;
 }
 

--- a/packages/flame/.docu/node/server.ts
+++ b/packages/flame/.docu/node/server.ts
@@ -103,8 +103,8 @@ const server = Bun.serve({
 
     if (builder) {
       const pluginResponse = await builder.runHandleRequest(req, {
-        port: server.port,
-        hostname: server.hostname,
+        port: server.port!,
+        hostname: server.hostname!,
       });
       if (pluginResponse) {
         logger.request(

--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -63,8 +63,9 @@
     "bun-plugin-tailwind": "^0.1.2",
     "daisyui": "^5.5.19",
     "lucide-react": "^1.14.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "unified": "^11.0.0"
   },
   "peerDependencies": {
     "@sentry/bun": "^10.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      unified:
+        specifier: ^11.0.0
+        version: 11.0.5
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.1
@@ -12334,7 +12337,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -12367,7 +12370,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -12382,7 +12385,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       "@rtsao/scc": 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Perubahan

### 1. Relative asset paths
CSS/JS/favicon paths diubah dari absolut (`/assets/...`) ke relative (`assets/`, `../assets/`, `../../assets/`) berdasarkan kedalaman halaman. Fix untuk subfolder deployment seperti GitHub Pages project sites.

### 2. React 19 SSR build error
Fix `ReactSharedInternals.H` null pointer error. Penyebab: bun cache menyimpan 2 versi React (19.2.3 + 19.2.7). Saat SSR, react-dom 19.2.7 render komponen yang resolve react 19.2.3 → hooks dispatcher null. Di-fix via pnpm overrides.

### 3. 7 TypeScript errors
- `Lucide.tsx` — type cast
- `Search.tsx` — `size="s"` → `"sm"`
- `plugin.ts` — missing re-export
- `server-routes.ts` — optional field
- `server.ts` — non-null assertions
- `package.json` — react `^19.0.0` → `^19.2.7`, +unified

## Testing
- ✅ Build: 28 pages, 0 errors
- ✅ Tests: 14 suites, 233 passed