### PR TITLE
fix(flame): add security headers to plugin handleRequest + fix dev server asset depth

### DIFF
--- a/.changeset/smooth-dolphins-yawn.md
+++ b/.changeset/smooth-dolphins-yawn.md
@@ -1,0 +1,13 @@
+---
+"@docubook/flame": patch
+---
+
+fix(flame): add security headers to plugin handleRequest + fix dev server asset depth
+
+- Plugin `handleRequest` responses now auto-inject security headers
+  (`Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`,
+  `Referrer-Policy`, `Permissions-Policy`) and `Content-Security-Policy` for
+  HTML responses. Plugin's own headers take precedence over defaults.
+- Dev server now passes correct `depth` to `htmlShell`, fixing broken
+  CSS/JS asset paths on nested docs pages (e.g. `/docs/getting-started/introduction`
+  was requesting `assets/client.css` → wrong path instead of `../../assets/client.css`).

--- a/packages/flame/.docu/node/server-routes.ts
+++ b/packages/flame/.docu/node/server-routes.ts
@@ -28,7 +28,8 @@ function createHtmlResponse(
   description: string,
   body: string,
   status: number,
-  state: ServerState
+  state: ServerState,
+  depth = 0
 ): Response {
   const nonce = generateNonce();
   const favicon = state.docuConfig.meta?.favicon || "/favicon.ico";
@@ -42,6 +43,7 @@ function createHtmlResponse(
     nonce,
     extraScripts: hmrScript(nonce),
     themeCss: state.inlineThemeCss,
+    depth,
   });
   return htmlResponse(html, nonce, status, process.env.NODE_ENV !== "production");
 }
@@ -140,6 +142,9 @@ async function renderDocsServerPage(
 
   const body = renderToString(page);
 
+  // Match build.ts depth calculation: slug.split("/").length, fallback to 1 for empty
+  const depth = slug.length || 1;
+
   if (state.builder) {
     const ctx: PageContext = {
       slug: slug.join("/") || "/",
@@ -164,12 +169,13 @@ async function renderDocsServerPage(
       themeCss: state.inlineThemeCss,
       headExtra,
       bodyExtra,
+      depth,
     });
     html = await state.builder.runTransformHtmlChain(html, ctx);
     return htmlResponse(html, nonce, 200, process.env.NODE_ENV !== "production");
   }
 
-  return createHtmlResponse(title, description, body, 200, state);
+  return createHtmlResponse(title, description, body, 200, state, depth);
 }
 
 function renderPage(
@@ -178,7 +184,8 @@ function renderPage(
   description: string,
   status: number,
   state: ServerState,
-  props: Record<string, unknown> = {}
+  props: Record<string, unknown> = {},
+  depth = 0
 ): Response {
   const page = React.createElement(
     DocsLayout,
@@ -186,19 +193,20 @@ function renderPage(
     React.createElement(Component, props)
   );
   const body = renderToString(page);
-  return createHtmlResponse(title, description, body, status, state);
+  return createHtmlResponse(title, description, body, status, state, depth);
 }
 
 export async function handleDocsIndex(state: ServerState): Promise<Response> {
   const doc = await getDocsForSlug("", state);
-  if (!doc) return renderPage(NotFoundPage, "404 - Not Found", "", 404, state);
+  if (!doc) return renderPage(NotFoundPage, "404 - Not Found", "", 404, state, {}, 1);
   return renderDocsServerPage(doc, [], "/docs", state);
 }
 
 export async function handleDocsRoute(slug: string[], state: ServerState): Promise<Response> {
   const path = slug.join("/");
   const doc = await getDocsForSlug(path, state);
-  if (!doc) return renderPage(NotFoundPage, "404 - Not Found", "", 404, state);
+  if (!doc)
+    return renderPage(NotFoundPage, "404 - Not Found", "", 404, state, {}, slug.length || 1);
   return renderDocsServerPage(doc, slug, `/docs/${path}`, state);
 }
 
@@ -214,8 +222,8 @@ export function handleIndex(state: ServerState): Response {
   );
 }
 
-export function handleNotFound(state: ServerState): Response {
-  return renderPage(NotFoundPage, "404 - Not Found", "", 404, state);
+export function handleNotFound(state: ServerState, depth = 0): Response {
+  return renderPage(NotFoundPage, "404 - Not Found", "", 404, state, {}, depth);
 }
 
 export function serveStatic(pathname: string): Response | null {

--- a/packages/flame/.docu/node/server.ts
+++ b/packages/flame/.docu/node/server.ts
@@ -15,6 +15,7 @@ import {
   serverErrorResponse,
   type ServerState,
 } from "./server-routes";
+import { SECURITY_HEADERS, cspHeader, generateNonce } from "./security";
 
 const docuConfig = loadDocuConfig();
 
@@ -107,13 +108,30 @@ const server = Bun.serve({
         hostname: server.hostname!,
       });
       if (pluginResponse) {
+        // Wrap plugin response with security headers.
+        // Plugin's own headers take precedence over defaults.
+        const securedHeaders = new Headers(pluginResponse.headers);
+        for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+          if (!securedHeaders.has(key)) {
+            securedHeaders.set(key, value);
+          }
+        }
+        const contentType = securedHeaders.get("Content-Type") || "";
+        if (contentType.includes("text/html") && !securedHeaders.has("Content-Security-Policy")) {
+          securedHeaders.set("Content-Security-Policy", cspHeader(generateNonce(), true));
+        }
+        const securedResponse = new Response(pluginResponse.body, {
+          status: pluginResponse.status,
+          statusText: pluginResponse.statusText,
+          headers: securedHeaders,
+        });
         logger.request(
           req.method,
           pathname,
-          pluginResponse.status,
+          securedResponse.status,
           Math.round(performance.now() - startTime)
         );
-        return pluginResponse;
+        return securedResponse;
       }
     }
 


### PR DESCRIPTION
## Perubahan

### 1. Security headers untuk plugin `handleRequest`

Sebelumnya response dari plugin dikirim ke browser **tanpa satupun security headers** — rawan XSS jika plugin membuat API endpoint yang echo user input.

**Sesudah**: response plugin otomatis di-inject:
| Header | Value |
|---|---|
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` |
| `X-Frame-Options` | `DENY` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |
| `Content-Security-Policy` | (khusus `text/html`) dengan nonce |

Plugin tetap bisa **override** — jika plugin set header sendiri, nilai plugin yang dipakai.

### 2. Fix dev server asset path depth

**Masalah**: Dev server render `htmlShell` tanpa parameter `depth`, jadi `assetPrefix` selalu `"assets/"`. Untuk halaman di `/docs/getting-started/introduction`, browser resolve `assets/client.css` ke `/docs/getting-started/assets/client.css` — **salah**, karena aset sebenarnya ada di root `/assets/` (dari `dist/assets/`).

Akibatnya CSS/JS gagal load dengan error:
```
Refused to apply style from '.../client.css' because its MIME type ('text/html')
is not a supported stylesheet MIME type
```

**Sesudah**: Dev server sekarang passing `depth` yang benar ke `htmlShell`, sama dengan yang dilakukan `build.ts`:

| Halaman | depth | assetPrefix | Resolve ke |
|---|---|---|---|
| `/` (landing) | 0 | `assets/` | `/assets/` ✅ |
| `/docs/` | 1 | `../assets/` | `/assets/` ✅ |
| `/docs/getting-started` | 1 | `../assets/` | `/assets/` ✅ |
| `/docs/getting-started/introduction` | 2 | `../../assets/` | `/assets/` ✅ |

### Files Changed

| File | Perubahan |
|---|---|
| `packages/flame/.docu/node/server.ts` | +20/-2 — security headers wrapper untuk plugin handleRequest |
| `packages/flame/.docu/node/server-routes.ts` | +16/-8 — depth parameter di createHtmlResponse, renderDocsServerPage, renderPage |
| `.changeset/smooth-dolphins-yawn.md` | Baru — patch bump @docubook/flame