### PR TITLE
feat(flame): add sanitization warning and runtime type guard for injectHead/injectBody

### DIFF
--- a/.changeset/calm-hotels-exercise.md
+++ b/.changeset/calm-hotels-exercise.md
@@ -1,0 +1,10 @@
+---
+"@docubook/flame": patch
+---
+
+Add sanitization warning and runtime type guard for injectHead/injectBody plugin hooks
+
+- Add JSDoc `⚠️` sanitization warning on `injectHead` and `injectBody` methods
+  in PluginBuilder interface
+- Add runtime type guard in `collectBody` and `collectHead` to validate return
+  values are `string | string[]`, rejecting non-strings with `console.warn`

--- a/packages/flame/.docu/__tests__/plugin.test.ts
+++ b/packages/flame/.docu/__tests__/plugin.test.ts
@@ -194,6 +194,41 @@ describe("BuildPluginBuilder — Execution", () => {
       builder.injectHead(() => ["<meta a>", "<meta b>"]);
       expect(builder.collectHead(noCtx)).toEqual(["<meta a>", "<meta b>"]);
     });
+
+    it("skips non-string items in array with warning", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      builder.injectBody(() => ["<div>", 42, "</div>"] as any);
+      expect(builder.collectBody(noCtx)).toEqual(["<div>", "</div>"]);
+      expect(warn).toHaveBeenCalledWith(
+        "[plugin] injectBody callback returned non-string item (got number), skipping"
+      );
+      warn.mockRestore();
+    });
+
+    it("skips non-string non-array result with warning", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      builder.injectHead(() => 42 as any);
+      expect(builder.collectHead(noCtx)).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(
+        "[plugin] injectHead callback returned unexpected type (got number), expected string or string[], skipping"
+      );
+      warn.mockRestore();
+    });
+
+    it("skips object result with warning", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      builder.injectBody(() => ({}) as any);
+      expect(builder.collectBody(noCtx)).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(
+        "[plugin] injectBody callback returned unexpected type (got object), expected string or string[], skipping"
+      );
+      warn.mockRestore();
+    });
+
+    it("keeps strings in mixed array, skips non-strings", () => {
+      builder.injectHead(() => ["<meta a>", 1, "<meta b>", {}, null] as any);
+      expect(builder.collectHead(noCtx)).toEqual(["<meta a>", "<meta b>"]);
+    });
   });
 
   describe("collectRemarkPlugins / collectRehypePlugins", () => {

--- a/packages/flame/.docu/node/plugin-builder.ts
+++ b/packages/flame/.docu/node/plugin-builder.ts
@@ -52,23 +52,7 @@ export class BuildPluginBuilder implements PluginBuilder {
       try {
         const result = cb(context);
         if (result) {
-          if (Array.isArray(result)) {
-            for (const item of result) {
-              if (typeof item === "string") {
-                items.push(item);
-              } else {
-                console.warn(
-                  `[plugin] injectBody callback returned non-string item (got ${typeof item}), skipping`
-                );
-              }
-            }
-          } else if (typeof result === "string") {
-            items.push(result);
-          } else {
-            console.warn(
-              `[plugin] injectBody callback returned unexpected type (got ${typeof result}), expected string or string[], skipping`
-            );
-          }
+          this.collectItems(items, result, "injectBody");
         }
       } catch (err) {
         throw new Error(
@@ -95,23 +79,7 @@ export class BuildPluginBuilder implements PluginBuilder {
       try {
         const result = cb(context);
         if (result) {
-          if (Array.isArray(result)) {
-            for (const item of result) {
-              if (typeof item === "string") {
-                items.push(item);
-              } else {
-                console.warn(
-                  `[plugin] injectHead callback returned non-string item (got ${typeof item}), skipping`
-                );
-              }
-            }
-          } else if (typeof result === "string") {
-            items.push(result);
-          } else {
-            console.warn(
-              `[plugin] injectHead callback returned unexpected type (got ${typeof result}), expected string or string[], skipping`
-            );
-          }
+          this.collectItems(items, result, "injectHead");
         }
       } catch (err) {
         throw new Error(
@@ -485,5 +453,29 @@ export class BuildPluginBuilder implements PluginBuilder {
    */
   transformHtml(callback: (html: string, context: PageContext) => Awaitable<string>): void {
     this._transformHtml.push(callback);
+  }
+
+  /**
+   * Collect items from a callback result, filtering only valid strings.
+   * Non-string items and unexpected types are logged as warnings.
+   */
+  private collectItems(items: string[], result: string | string[], hookName: string): void {
+    if (Array.isArray(result)) {
+      for (const item of result) {
+        if (typeof item === "string") {
+          items.push(item);
+        } else {
+          console.warn(
+            `[plugin] ${hookName} callback returned non-string item (got ${typeof item}), skipping`
+          );
+        }
+      }
+    } else if (typeof result === "string") {
+      items.push(result);
+    } else {
+      console.warn(
+        `[plugin] ${hookName} callback returned unexpected type (got ${typeof result}), expected string or string[], skipping`
+      );
+    }
   }
 }

--- a/packages/flame/.docu/node/plugin-builder.ts
+++ b/packages/flame/.docu/node/plugin-builder.ts
@@ -53,9 +53,21 @@ export class BuildPluginBuilder implements PluginBuilder {
         const result = cb(context);
         if (result) {
           if (Array.isArray(result)) {
-            items.push(...result);
-          } else {
+            for (const item of result) {
+              if (typeof item === "string") {
+                items.push(item);
+              } else {
+                console.warn(
+                  `[plugin] injectBody callback returned non-string item (got ${typeof item}), skipping`
+                );
+              }
+            }
+          } else if (typeof result === "string") {
             items.push(result);
+          } else {
+            console.warn(
+              `[plugin] injectBody callback returned unexpected type (got ${typeof result}), expected string or string[], skipping`
+            );
           }
         }
       } catch (err) {
@@ -84,9 +96,21 @@ export class BuildPluginBuilder implements PluginBuilder {
         const result = cb(context);
         if (result) {
           if (Array.isArray(result)) {
-            items.push(...result);
-          } else {
+            for (const item of result) {
+              if (typeof item === "string") {
+                items.push(item);
+              } else {
+                console.warn(
+                  `[plugin] injectHead callback returned non-string item (got ${typeof item}), skipping`
+                );
+              }
+            }
+          } else if (typeof result === "string") {
             items.push(result);
+          } else {
+            console.warn(
+              `[plugin] injectHead callback returned unexpected type (got ${typeof result}), expected string or string[], skipping`
+            );
           }
         }
       } catch (err) {

--- a/packages/flame/.docu/node/plugin.ts
+++ b/packages/flame/.docu/node/plugin.ts
@@ -167,6 +167,9 @@ export interface PluginBuilder {
    * Register a callback that returns HTML strings to inject inside `<head>`.
    * Results from all plugins are merged and deduplicated.
    *
+   * ⚠️ Sanitize any user-controlled or external data before injecting.
+   * Plugin-provided strings are injected raw into the final HTML.
+   *
    * Use for: analytics snippets, meta tags, stylesheet links.
    *
    * @param callback - Returns a single HTML string or an array. Called once per page.
@@ -181,6 +184,9 @@ export interface PluginBuilder {
   /**
    * Register a callback that returns HTML strings to inject before `</body>`.
    * Results from all plugins are merged and deduplicated.
+   *
+   * ⚠️ Sanitize any user-controlled or external data before injecting.
+   * Plugin-provided strings are injected raw into the final HTML.
    *
    * Use for: chat widgets, live-script loaders, deferred scripts.
    *


### PR DESCRIPTION
- Add JSDoc sanitization warning to injectHead and injectBody in PluginBuilder
- Add runtime type guard in collectBody and collectHead to validate return values are string | string[], rejecting non-strings with console.warn