### PR TITLE
fix(flame): validate frontmatter return types for XSS defense

### DIFF
--- a/.changeset/taste-of-grape.md
+++ b/.changeset/taste-of-grape.md
@@ -1,0 +1,14 @@
+---
+"@docubook/flame": patch
+---
+
+feat(security): validate transformFrontmatter return values
+
+Add runtime type guard in `runTransformFrontmatterChain` to reject non-plain-object
+return values from plugin callbacks (array, string, number) with a console warning.
+Previously only `undefined` and `null` were filtered — invalid types could produce
+`[object Object]` in rendered HTML.
+
+Add runtime type guard for frontmatter `title` and `description` in build and
+server pipelines — values that aren't strings now fall back to slug or empty
+string instead of producing `[object Object]` or unexpected type coercion.

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -1,0 +1,30 @@
+name: Pullfrog
+run-name: ${{ inputs.name || github.workflow }}
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        type: string
+        description: Agent prompt
+      name:
+        type: string
+        description: Run name
+
+permissions:
+  contents: read
+
+jobs:
+  pullfrog:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Run agent
+        uses: pullfrog/pullfrog@v0
+        with:
+          prompt: ${{ inputs.prompt }}

--- a/packages/flame/.docu/__tests__/plugin.test.ts
+++ b/packages/flame/.docu/__tests__/plugin.test.ts
@@ -156,6 +156,33 @@ describe("BuildPluginBuilder — Execution", () => {
       );
       expect(result).toEqual({ original: true });
     });
+
+    it("skips array return with warning", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      builder.transformFrontmatter(() => [] as any);
+      const result = await builder.runTransformFrontmatterChain({ key: "val" }, pageCtxFor("test"));
+      expect(result).toEqual({ key: "val" });
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/invalid type.*skipping/));
+      warn.mockRestore();
+    });
+
+    it("skips string return with warning", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      builder.transformFrontmatter(() => "oops" as any);
+      const result = await builder.runTransformFrontmatterChain({ key: "val" }, pageCtxFor("test"));
+      expect(result).toEqual({ key: "val" });
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/invalid type.*skipping/));
+      warn.mockRestore();
+    });
+
+    it("skips numeric return with warning", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      builder.transformFrontmatter(() => 42 as any);
+      const result = await builder.runTransformFrontmatterChain({ key: "val" }, pageCtxFor("test"));
+      expect(result).toEqual({ key: "val" });
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/invalid type.*skipping/));
+      warn.mockRestore();
+    });
   });
 
   describe("runTransformHtmlChain", () => {

--- a/packages/flame/.docu/node/build.ts
+++ b/packages/flame/.docu/node/build.ts
@@ -112,8 +112,9 @@ async function renderDocsPage(
     });
   }
 
-  const title = (frontmatter.title as string) || slug || "Docs";
-  const description = (frontmatter.description as string) || "";
+  const title = (typeof frontmatter.title === "string" ? frontmatter.title : "") || slug || "Docs";
+  const description =
+    (typeof frontmatter.description === "string" ? frontmatter.description : "") || "";
   const slugParts = slug ? slug.split("/") : [];
 
   const page = React.createElement(

--- a/packages/flame/.docu/node/build.ts
+++ b/packages/flame/.docu/node/build.ts
@@ -113,8 +113,7 @@ async function renderDocsPage(
   }
 
   const title = (typeof frontmatter.title === "string" ? frontmatter.title : "") || slug || "Docs";
-  const description =
-    (typeof frontmatter.description === "string" ? frontmatter.description : "") || "";
+  const description = typeof frontmatter.description === "string" ? frontmatter.description : "";
   const slugParts = slug ? slug.split("/") : [];
 
   const page = React.createElement(

--- a/packages/flame/.docu/node/plugin-builder.ts
+++ b/packages/flame/.docu/node/plugin-builder.ts
@@ -365,6 +365,8 @@ export class BuildPluginBuilder implements PluginBuilder {
    * Each callback receives the **previous** callback's return value (or the
    * original frontmatter for the first). Callbacks that return `undefined` or
    * `null` pass the current value through unchanged.
+   * Callbacks that return a non-object (string, number, array) are skipped
+   * with a console warning — only plain objects are accepted.
    * Errors inside individual callbacks are caught and logged — the current
    * frontmatter passes through unchanged for that step.
    *
@@ -381,7 +383,13 @@ export class BuildPluginBuilder implements PluginBuilder {
       try {
         const next = await this._transformFrontmatter[i](result, context);
         if (next !== undefined && next !== null) {
-          result = next;
+          if (typeof next === "object" && !Array.isArray(next)) {
+            result = next;
+          } else {
+            console.warn(
+              `[plugin] transformFrontmatter callback #${i + 1} returned invalid type (expected a plain object), skipping`
+            );
+          }
         }
       } catch (err) {
         console.error(
@@ -421,6 +429,10 @@ export class BuildPluginBuilder implements PluginBuilder {
    * Register a callback to mutate frontmatter before MDX compilation.
    * Callbacks are chained in a waterfall: the return value of one is passed
    * as input to the next. Return `undefined` to pass through unchanged.
+   *
+   * **Note:** Only plain objects are accepted as return values. Returning
+   * a string, number, or array will be silently skipped with a warning.
+   * Plugin authors should validate their return values before returning.
    *
    * @param callback - Receives frontmatter object and page context.
    *

--- a/packages/flame/.docu/node/server-routes.ts
+++ b/packages/flame/.docu/node/server-routes.ts
@@ -126,7 +126,7 @@ async function renderDocsServerPage(
     slug.join("/") ||
     "Docs";
   const description =
-    (typeof doc.frontmatter.description === "string" ? doc.frontmatter.description : "") || "";
+    typeof doc.frontmatter.description === "string" ? doc.frontmatter.description : "";
 
   const page = React.createElement(
     DocsLayout,

--- a/packages/flame/.docu/node/server-routes.ts
+++ b/packages/flame/.docu/node/server-routes.ts
@@ -121,8 +121,12 @@ async function renderDocsServerPage(
   pathname: string,
   state: ServerState
 ): Promise<Response> {
-  const title = (doc.frontmatter.title as string) || slug.join("/") || "Docs";
-  const description = (doc.frontmatter.description as string) || "";
+  const title =
+    (typeof doc.frontmatter.title === "string" ? doc.frontmatter.title : "") ||
+    slug.join("/") ||
+    "Docs";
+  const description =
+    (typeof doc.frontmatter.description === "string" ? doc.frontmatter.description : "") || "";
 
   const page = React.createElement(
     DocsLayout,


### PR DESCRIPTION
@pullfrog

## Summary

Add runtime type validation for frontmatter values across the plugin chain and build/server pipeline to prevent non-string/non-object values from producing `[object Object]` in rendered HTML.

## Changes

### 1. Plugin chain type guard (`plugin-builder.ts`)

`runTransformFrontmatterChain()` now validates that every callback return value is a plain object before applying it. If a plugin callback returns an array, string, or number:
- A `console.warn()` is emitted with the callback index
- The invalid value is **skipped** — the previous frontmatter passes through unchanged

Previously only `undefined` and `null` were filtered. Any other type (including arrays) would silently replace the frontmatter.

### 2. Frontmatter title/description runtime guard (`server-routes.ts`, `build.ts`)

```diff
- const title = (frontmatter.title as string) || slug || "Docs";
+ const title = (typeof frontmatter.title === "string" ? frontmatter.title : "") || slug || "Docs";
```

Replaced TypeScript-only casts (`as string`) with actual runtime `typeof` checks. When frontmatter `title` or `description` is a non-string (number, object, array), the value falls back to the slug or empty string instead of passing `[object Object]` into `<title>` or meta description.

### 3. Tests

- 3 new unit tests in `plugin.test.ts` for array, string, and numeric returns from `transformFrontmatter` callbacks
- No separate test for the `typeof` guard in `server-routes.ts`/`build.ts` — see **Why no dedicated tests?** below

### 4. Documentation

- JSDoc on `transformFrontmatter()` registration method updated with note about return type requirements
- Changeset added (`@docubook/flame`, patch)

---

## Why no dedicated tests for the runtime type guard?

The `typeof` guard in `server-routes.ts` and `build.ts` is **defense-in-depth** — both layers around it are already tested:

| Layer | What guards | Test coverage |
|-------|-------------|--------------|
| **SEC-028** plugin chain | Rejects non-object returns from plugin callbacks | ✅ `plugin.test.ts` — array, string, numeric |
| **`typeof` guard** (this PR) | Rejects non-string title/description from MDX frontmatter | ⚪ not tested in isolation |
| **`Bun.escapeHTML()`** in `htmlShell` | Escapes any value rendered in `<title>` / meta tags | ✅ `server-routing.test.ts` — HTML escaping |

The guard itself is a one-liner (`typeof x === "string" ? x : ""`) — writing an isolated test for it would test the language runtime, not our logic. An integration test would require the full MDX compilation + build pipeline, which would be disproportionately heavy for a simple type check.

Both entry points for invalid data are already covered:
- **Plugin callbacks** → SEC-028 tests verify rejection
- **Raw MDX frontmatter** → unlikely to produce non-string title/description from YAML parsing, but the guard catches edge cases

The existing `server-routing.test.ts` ("escapes HTML in title and description") already verifies the output pipeline handles arbitrary strings correctly.