### PR TITLE
fix(flame): validate PORT env var and cleanup redundant plugin check

### DIFF
--- a/.changeset/tough-paths-buy.md
+++ b/.changeset/tough-paths-buy.md
@@ -6,6 +6,6 @@ fix: validate PORT env var with `parseInt` and range check (1–65535)
 
 Replace naive `Number(process.env.PORT ?? 3000)` with `parseInt(..., 10)` plus integer and range validation. Invalid values fall back to port 3000.
 
-refactor: remove redundant `hasPlugins` check in plugin setup
+refactor: remove redundant `hasPlugins` check in plugin setup (server.ts + build.ts)
 
-`builder` is already `null` when `hasPlugins` is falsy (from `hasPlugins ? new BuildPluginBuilder(docuConfig) : null`), so the extra `hasPlugins &&` guard was unnecessary.
+`builder` is already `null` when `hasPlugins` is falsy (from `hasPlugins ? new BuildPluginBuilder(docuConfig) : null`), so the extra `hasPlugins &&` guard was unnecessary in both the dev server and static build paths.

--- a/.changeset/tough-paths-buy.md
+++ b/.changeset/tough-paths-buy.md
@@ -1,0 +1,11 @@
+---
+'@docubook/flame': patch
+---
+
+fix: validate PORT env var with `parseInt` and range check (1–65535)
+
+Replace naive `Number(process.env.PORT ?? 3000)` with `parseInt(..., 10)` plus integer and range validation. Invalid values fall back to port 3000.
+
+refactor: remove redundant `hasPlugins` check in plugin setup
+
+`builder` is already `null` when `hasPlugins` is falsy (from `hasPlugins ? new BuildPluginBuilder(docuConfig) : null`), so the extra `hasPlugins &&` guard was unnecessary.

--- a/packages/flame/.docu/node/build.ts
+++ b/packages/flame/.docu/node/build.ts
@@ -220,7 +220,7 @@ async function build() {
 
   const hasPlugins = !!docuConfig.plugins?.length;
   const builder = hasPlugins ? new BuildPluginBuilder(docuConfig) : null;
-  if (hasPlugins && builder) {
+  if (builder) {
     const plugins = await loadPlugins(docuConfig.plugins!);
     for (const plugin of plugins) {
       await plugin.setup(builder);

--- a/packages/flame/.docu/node/server.ts
+++ b/packages/flame/.docu/node/server.ts
@@ -42,7 +42,7 @@ logger.routes();
 // Plugin setup — all hooks active (onLoad, remark/rehype, frontmatter, head/body, html transform, handleRequest)
 const hasPlugins = !!docuConfig.plugins?.length;
 const builder = hasPlugins ? new BuildPluginBuilder(docuConfig) : null;
-if (hasPlugins && builder) {
+if (builder) {
   const plugins = await loadPlugins(docuConfig.plugins!);
   for (const plugin of plugins) {
     await plugin.setup(builder);

--- a/packages/flame/.docu/node/server.ts
+++ b/packages/flame/.docu/node/server.ts
@@ -19,7 +19,8 @@ import { wrapPluginResponse } from "./security";
 
 const docuConfig = loadDocuConfig();
 
-const PORT = Number(process.env.PORT ?? 3000);
+const parsedPort = parseInt(process.env.PORT ?? "3000", 10);
+const PORT = Number.isInteger(parsedPort) && parsedPort > 0 && parsedPort <= 65535 ? parsedPort : 3000;
 
 logger.buildStart();
 


### PR DESCRIPTION
This PR applies 2/3 suggestions from code quality [AI findings](https://github.com/DocuBook/docubook/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts.

## Changes

### [`f23b97b`](https://github.com/DocuBook/docubook/commit/f23b97b) — refactor(flame): remove redundant `hasPlugins` check in plugin setup (server.ts)

`builder` is already `null` when `hasPlugins` is falsy (from `hasPlugins ? new BuildPluginBuilder(docuConfig) : null`), so `hasPlugins && builder` simplifies to just `builder`.

**File:** `packages/flame/.docu/node/server.ts`

### [`05af57a`](https://github.com/DocuBook/docubook/commit/05af57a) — fix(flame): apply same redundant guard cleanup to build.ts

Identical redundant `hasPlugins && builder` guard in the static build path. Applied the same simplification for consistency.

**File:** `packages/flame/.docu/node/build.ts`

### [`f0054ec`](https://github.com/DocuBook/docubook/commit/f0054ec) — fix(flame): validate PORT env var with `parseInt` and range check

Replace naive `Number(process.env.PORT ?? 3000)` with:
- `parseInt(..., 10)` — ensures radix 10
- integer + range validation (`1`–`65535`)
- fallback to `3000` for invalid values

**File:** `packages/flame/.docu/node/server.ts`

### [`9f00f40`](https://github.com/DocuBook/docubook/commit/b471e74) — chore: add changeset

Changeset file for `@docubook/flame` (patch).