### PR TITLE
refactor(flame): replace non-null assertions with safe defaults in plugin setup

### DIFF
--- a/.changeset/spotty-cycles-heal.md
+++ b/.changeset/spotty-cycles-heal.md
@@ -1,0 +1,16 @@
+---
+'@docubook/flame': patch
+---
+
+refactor: eliminate non-null assertions in plugin config handling
+
+Replace `!!docuConfig.plugins?.length` + `docuConfig.plugins!` pattern with
+explicit `docuConfig.plugins ?? []` default and `pluginsConfig.length > 0`
+in both build.ts and server.ts. Also fix `builder?: BuildPluginBuilder` param
+type to accept `null` explicitly, and replace `server.port!` with safe
+`server.port ?? PORT` fallback.
+
+- Removes unsafe non-null assertions (`!`) that could throw at runtime
+- Eliminates redundant `!!` double-negation
+- Keeps `const` semantics for builder variable
+- Ensures consistent plugin config handling across build + dev server

--- a/packages/flame/.docu/node/build.ts
+++ b/packages/flame/.docu/node/build.ts
@@ -82,7 +82,7 @@ async function renderDocsPage(
   rawMdx: string,
   filePath: string,
   gitDates?: Map<string, string>,
-  builder?: BuildPluginBuilder,
+  builder?: BuildPluginBuilder | null,
   nonce?: string
 ): Promise<string> {
   let content = rawMdx;
@@ -218,10 +218,10 @@ async function build() {
     };
   }
 
-  const hasPlugins = !!docuConfig.plugins?.length;
-  const builder = hasPlugins ? new BuildPluginBuilder(docuConfig) : null;
+  const pluginsConfig = docuConfig.plugins ?? [];
+  const builder = pluginsConfig.length > 0 ? new BuildPluginBuilder(docuConfig) : null;
   if (builder) {
-    const plugins = await loadPlugins(docuConfig.plugins!);
+    const plugins = await loadPlugins(pluginsConfig);
     for (const plugin of plugins) {
       await plugin.setup(builder);
     }

--- a/packages/flame/.docu/node/server.ts
+++ b/packages/flame/.docu/node/server.ts
@@ -20,7 +20,8 @@ import { wrapPluginResponse } from "./security";
 const docuConfig = loadDocuConfig();
 
 const parsedPort = parseInt(process.env.PORT ?? "3000", 10);
-const PORT = Number.isInteger(parsedPort) && parsedPort > 0 && parsedPort <= 65535 ? parsedPort : 3000;
+const PORT =
+  Number.isInteger(parsedPort) && parsedPort > 0 && parsedPort <= 65535 ? parsedPort : 3000;
 
 logger.buildStart();
 
@@ -41,10 +42,12 @@ logger.indexDone(records, Math.round(performance.now() - t));
 logger.routes();
 
 // Plugin setup — all hooks active (onLoad, remark/rehype, frontmatter, head/body, html transform, handleRequest)
-const hasPlugins = !!docuConfig.plugins?.length;
-const builder = hasPlugins ? new BuildPluginBuilder(docuConfig) : null;
+const pluginsConfig = docuConfig.plugins ?? [];
+const builder = pluginsConfig.length > 0 ? new BuildPluginBuilder(docuConfig) : null;
+
 if (builder) {
-  const plugins = await loadPlugins(docuConfig.plugins!);
+  const plugins = await loadPlugins(pluginsConfig);
+
   for (const plugin of plugins) {
     await plugin.setup(builder);
   }
@@ -194,4 +197,4 @@ const server = Bun.serve({
   },
 });
 
-logger.ready(server.port!, true);
+logger.ready(server.port ?? PORT, true);


### PR DESCRIPTION
## Description

Eliminates unsafe non-null assertions (`!`) and redundant double-negation (`!!`) in plugin configuration handling across `build.ts` and `server.ts`.

## Changes

- Replace `!!docuConfig.plugins?.length` + `docuConfig.plugins!` with explicit `docuConfig.plugins ?? []` default and `pluginsConfig.length > 0` in both files
- Fix `builder?: BuildPluginBuilder` param type to accept `null` explicitly in `renderDocsPage`
- Replace `server.port!` with safe `server.port ?? PORT` fallback
- Consistent pattern shared between build and dev server paths

## Impact

- Zero runtime behavior change
- Removes 2 non-null assertions that could throw at runtime if config is missing
- Keeps `const` semantics for `builder` variable