### PR TITLE
feat(flame): add sidebar.context configuration with dropdown and separator modes

### DIFF
--- a/.changeset/eleven-spoons-live.md
+++ b/.changeset/eleven-spoons-live.md
@@ -23,4 +23,24 @@ Add `sidebar.context` configuration with two modes: "dropdown" (default) and "se
 - Absent `sidebar` or `sidebar.context === "dropdown"` preserves existing behavior
 - Dropdown mode code path unchanged
 - Sublink.tsx behavior unchanged
-- All 291 tests pass
+
+---
+
+Expand `detectPlatformPath` platform support and improve `repo` schema
+
+**Platform detection (`node/helpers.ts`):**
+- Add explicit cases for `gitea.com` (Gitea Cloud) and `codeberg.org` (Forgejo)
+- Update JSDoc comment — fallback now described as "Gogs, Forgejo, or any self-hosted Gitea-compatible forge"
+- Previously only GitHub, GitLab, Bitbucket were explicit; all others fell through to GitHub-style fallback (incorrect for Gitea-based platforms)
+
+**Schema (`docu.schema.json`):**
+- `repo.url`: add `format: "uri"`, expand description to list all supported platforms, add `examples` for GitHub / GitLab / Bitbucket / Gitea / Codeberg
+- `repo.path`: add `pattern: \{filePath\}` for editor validation, expand description with format guide and auto-detect note, add `examples` covering root repo + monorepo + non-default branch for all platforms
+
+**Documentation (`README.md`):**
+- Add dedicated `### Repo & Edit Links` section with platform auto-detection table, property table, and three annotated override examples (monorepo, non-default branch, self-hosted GitLab on custom domain)
+- Update full config example — remove hardcoded `path` to reflect that it is optional for root repos
+
+**Tests:**
+- `helpers.test.ts`: add unit tests for `gitea.com` and `codeberg.org` in `detectPlatformPath` and platform integration loop (22 tests total)
+- `schema.test.ts`: add `docu.schema.json — repo.url field` and `docu.schema.json — repo.path field` describe blocks covering `format`, `pattern`, `examples`, and `description` content (22 schema tests total)

--- a/.changeset/eleven-spoons-live.md
+++ b/.changeset/eleven-spoons-live.md
@@ -1,0 +1,26 @@
+---
+"@docubook/flame": minor
+---
+
+Add `sidebar.context` configuration with two modes: "dropdown" (default) and "separator"
+
+**Schema & types:**
+- Add `sidebar` object to `docu.schema.json` with `context` enum `["dropdown", "separator"]`, default `"dropdown"`
+- Add `DocuSidebar` interface and optional `sidebar` field to `DocuConfig`
+
+**Separator mode components:**
+- New `SidebarGroupHeader` — renders icon (Lucide) + title for each context section
+- Separator branch in `Menu.tsx` — filters routes with `context`, renders headers + tree connector + nav items
+- `Context.tsx` returns `null` in separator mode (context switcher not needed)
+
+**Visual:**
+- Icon wrapped in styled span matching Context.tsx dropdown pattern
+- Padding aligned with level-0 Sublink items
+- Tree connector line (`border-l-2`) connecting section header to its items
+- Tight spacing between header and items
+
+**Backward compatible:**
+- Absent `sidebar` or `sidebar.context === "dropdown"` preserves existing behavior
+- Dropdown mode code path unchanged
+- Sublink.tsx behavior unchanged
+- All 291 tests pass

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,8 +32,8 @@
     "lucide-react": "^1.7.0",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",
-    "react": "19.2.3",
-    "react-dom": "19.2.3",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.6.1"
   },
@@ -53,9 +53,5 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.2"
-  },
-  "overrides": {
-    "@types/react": "19.2.8",
-    "@types/react-dom": "19.2.3"
   }
 }

--- a/packages/flame/.docu/__tests__/helpers.test.ts
+++ b/packages/flame/.docu/__tests__/helpers.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock paths module BEFORE any import of helpers, because helpers.ts calls
+// loadDocuConfig() at module scope (top-level constant).
+vi.mock("../node/paths", () => ({
+  loadDocuConfig: vi.fn(() => ({
+    repo: { url: "", path: "", edit: false },
+    footer: { social: [] },
+  })),
+}));
+
+import {
+  detectPlatformPath,
+  getEditLink,
+  isEditEnabled,
+  getRepoUrl,
+  getSocialLinks,
+} from "../node/helpers";
+
+// ---------------------------------------------------------------------------
+// detectPlatformPath — pure function, no config dependency
+// ---------------------------------------------------------------------------
+describe("detectPlatformPath", () => {
+  it("returns GitHub blob path for github.com", () => {
+    expect(detectPlatformPath("https://github.com/owner/repo")).toBe("blob/main/{filePath}");
+  });
+
+  it("returns GitLab blob path for gitlab.com", () => {
+    expect(detectPlatformPath("https://gitlab.com/owner/repo")).toBe("-/blob/main/{filePath}");
+  });
+
+  it("returns Bitbucket src path for bitbucket.org", () => {
+    expect(detectPlatformPath("https://bitbucket.org/owner/repo")).toBe("src/main/{filePath}");
+  });
+
+  it("returns Gitea/Gogs fallback for self-hosted forge (unknown host)", () => {
+    expect(detectPlatformPath("https://gitea.example.com/owner/repo")).toBe(
+      "src/branch/main/{filePath}"
+    );
+  });
+
+  it("returns Gitea path for gitea.com (cloud)", () => {
+    expect(detectPlatformPath("https://gitea.com/owner/repo")).toBe("src/branch/main/{filePath}");
+  });
+
+  it("returns Forgejo path for codeberg.org", () => {
+    expect(detectPlatformPath("https://codeberg.org/owner/repo")).toBe(
+      "src/branch/main/{filePath}"
+    );
+  });
+
+  it("falls back to GitHub-style for an invalid/non-URL string", () => {
+    expect(detectPlatformPath("not-a-url")).toBe("blob/main/{filePath}");
+  });
+
+  it("falls back to GitHub-style for an empty string", () => {
+    expect(detectPlatformPath("")).toBe("blob/main/{filePath}");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEditLink
+// Note: docuConfig is captured at module init time, so these tests verify the
+// logic paths reachable from the single module-level config snapshot.
+// We use a shared config (set once per describe) to cover each branch.
+// ---------------------------------------------------------------------------
+describe("getEditLink — uses detectPlatformPath when repo.path is empty", () => {
+  it("builds GitHub edit link for docs/intro.mdx", () => {
+    // Default mock has repo.path = "" → falls through to detectPlatformPath
+    const result = getEditLink("https://github.com/owner/repo", "docs/intro.mdx");
+    expect(result).toBe("https://github.com/owner/repo/blob/main/docs/intro.mdx");
+  });
+
+  it("strips leading slash from filePath", () => {
+    const result = getEditLink("https://github.com/owner/repo", "/docs/intro.mdx");
+    expect(result).toBe("https://github.com/owner/repo/blob/main/docs/intro.mdx");
+  });
+
+  it("encodes spaces in filePath segments", () => {
+    const result = getEditLink(
+      "https://github.com/owner/repo",
+      "docs/getting started/intro file.mdx"
+    );
+    expect(result).toBe(
+      "https://github.com/owner/repo/blob/main/docs/getting%20started/intro%20file.mdx"
+    );
+  });
+
+  it("builds GitLab edit link", () => {
+    const result = getEditLink("https://gitlab.com/owner/repo", "docs/api.mdx");
+    expect(result).toBe("https://gitlab.com/owner/repo/-/blob/main/docs/api.mdx");
+  });
+
+  it("builds Bitbucket edit link", () => {
+    const result = getEditLink("https://bitbucket.org/owner/repo", "docs/api.mdx");
+    expect(result).toBe("https://bitbucket.org/owner/repo/src/main/docs/api.mdx");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isEditEnabled — reads from module-level docuConfig
+// ---------------------------------------------------------------------------
+describe("isEditEnabled", () => {
+  it("returns false with the default mock (edit: false)", () => {
+    expect(isEditEnabled()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRepoUrl — reads from module-level docuConfig
+// ---------------------------------------------------------------------------
+describe("getRepoUrl", () => {
+  it("returns empty string with the default mock (url: '')", () => {
+    expect(getRepoUrl()).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSocialLinks — reads from module-level docuConfig
+// ---------------------------------------------------------------------------
+describe("getSocialLinks", () => {
+  it("returns empty array with the default mock (social: [])", () => {
+    expect(getSocialLinks()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: verify detectPlatformPath drives getEditLink correctly
+// for all supported hosts — using only the pure function path.
+// ---------------------------------------------------------------------------
+describe("getEditLink — platform integration via detectPlatformPath", () => {
+  const cases = [
+    {
+      label: "github.com",
+      repoUrl: "https://github.com/org/repo",
+      filePath: "guide/intro.mdx",
+      expected: "https://github.com/org/repo/blob/main/guide/intro.mdx",
+    },
+    {
+      label: "gitlab.com",
+      repoUrl: "https://gitlab.com/org/repo",
+      filePath: "guide/intro.mdx",
+      expected: "https://gitlab.com/org/repo/-/blob/main/guide/intro.mdx",
+    },
+    {
+      label: "bitbucket.org",
+      repoUrl: "https://bitbucket.org/org/repo",
+      filePath: "guide/intro.mdx",
+      expected: "https://bitbucket.org/org/repo/src/main/guide/intro.mdx",
+    },
+    {
+      label: "gitea.com (cloud)",
+      repoUrl: "https://gitea.com/org/repo",
+      filePath: "guide/intro.mdx",
+      expected: "https://gitea.com/org/repo/src/branch/main/guide/intro.mdx",
+    },
+    {
+      label: "codeberg.org (Forgejo)",
+      repoUrl: "https://codeberg.org/org/repo",
+      filePath: "guide/intro.mdx",
+      expected: "https://codeberg.org/org/repo/src/branch/main/guide/intro.mdx",
+    },
+    {
+      label: "self-hosted gitea",
+      repoUrl: "https://gitea.myorg.io/org/repo",
+      filePath: "guide/intro.mdx",
+      expected: "https://gitea.myorg.io/org/repo/src/branch/main/guide/intro.mdx",
+    },
+  ];
+
+  for (const { label, repoUrl, filePath, expected } of cases) {
+    it(`builds correct URL for ${label}`, () => {
+      expect(getEditLink(repoUrl, filePath)).toBe(expected);
+    });
+  }
+});

--- a/packages/flame/.docu/__tests__/schema.test.ts
+++ b/packages/flame/.docu/__tests__/schema.test.ts
@@ -2,6 +2,52 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+describe("docu.schema.json — sidebar field", () => {
+  const schemaPath = join(import.meta.dirname, "..", "..", "docu.schema.json");
+  const schema: Record<string, unknown> = JSON.parse(readFileSync(schemaPath, "utf-8"));
+
+  it("has a sidebar property", () => {
+    const properties = schema.properties as Record<string, unknown>;
+    expect(properties.sidebar).toBeDefined();
+  });
+
+  it("defines sidebar as object type", () => {
+    const sidebar = (schema.properties as Record<string, unknown>).sidebar as Record<
+      string,
+      unknown
+    >;
+    expect(sidebar.type).toBe("object");
+  });
+
+  it("has context enum with dropdown and separator", () => {
+    const sidebar = (schema.properties as Record<string, unknown>).sidebar as Record<
+      string,
+      unknown
+    >;
+    const context = sidebar.properties as Record<string, unknown>;
+    const contextProp = context.context as Record<string, unknown>;
+    expect(contextProp.enum).toEqual(["dropdown", "separator"]);
+  });
+
+  it("defaults context to dropdown", () => {
+    const sidebar = (schema.properties as Record<string, unknown>).sidebar as Record<
+      string,
+      unknown
+    >;
+    const context = sidebar.properties as Record<string, unknown>;
+    const contextProp = context.context as Record<string, unknown>;
+    expect(contextProp.default).toBe("dropdown");
+  });
+
+  it("does not allow additional properties on sidebar", () => {
+    const sidebar = (schema.properties as Record<string, unknown>).sidebar as Record<
+      string,
+      unknown
+    >;
+    expect(sidebar.additionalProperties).toBe(false);
+  });
+});
+
 describe("docu.schema.json — plugins field", () => {
   const schemaPath = join(import.meta.dirname, "..", "..", "docu.schema.json");
   const schema: Record<string, unknown> = JSON.parse(readFileSync(schemaPath, "utf-8"));

--- a/packages/flame/.docu/__tests__/schema.test.ts
+++ b/packages/flame/.docu/__tests__/schema.test.ts
@@ -98,3 +98,104 @@ describe("docu.schema.json — plugins field", () => {
     expect(schema.$schema).toBe("http://json-schema.org/draft-07/schema#");
   });
 });
+
+describe("docu.schema.json — repo.url field", () => {
+  const schemaPath = join(import.meta.dirname, "..", "..", "docu.schema.json");
+  const schema: Record<string, unknown> = JSON.parse(readFileSync(schemaPath, "utf-8"));
+
+  const repoProps = ((schema.properties as Record<string, unknown>).repo as Record<string, unknown>)
+    .properties as Record<string, unknown>;
+
+  it("defines url as string type", () => {
+    const url = repoProps.url as Record<string, unknown>;
+    expect(url.type).toBe("string");
+  });
+
+  it("has format uri on url", () => {
+    const url = repoProps.url as Record<string, unknown>;
+    expect(url.format).toBe("uri");
+  });
+
+  it("description mentions all supported platforms", () => {
+    const url = repoProps.url as Record<string, unknown>;
+    const desc = url.description as string;
+    expect(desc).toContain("GitHub");
+    expect(desc).toContain("GitLab");
+    expect(desc).toContain("Bitbucket");
+    expect(desc).toContain("Gitea");
+    expect(desc).toContain("Codeberg");
+    expect(desc).toContain("Forgejo");
+  });
+
+  it("has examples for all major platforms", () => {
+    const url = repoProps.url as Record<string, unknown>;
+    const examples = url.examples as string[];
+    expect(examples.some((e) => e.includes("github.com"))).toBe(true);
+    expect(examples.some((e) => e.includes("gitlab.com"))).toBe(true);
+    expect(examples.some((e) => e.includes("bitbucket.org"))).toBe(true);
+    expect(examples.some((e) => e.includes("gitea.com"))).toBe(true);
+    expect(examples.some((e) => e.includes("codeberg.org"))).toBe(true);
+  });
+});
+
+describe("docu.schema.json — repo.path field", () => {
+  const schemaPath = join(import.meta.dirname, "..", "..", "docu.schema.json");
+  const schema: Record<string, unknown> = JSON.parse(readFileSync(schemaPath, "utf-8"));
+
+  const repoProps = ((schema.properties as Record<string, unknown>).repo as Record<string, unknown>)
+    .properties as Record<string, unknown>;
+
+  it("has a path property", () => {
+    expect(repoProps.path).toBeDefined();
+  });
+
+  it("defines path as string type", () => {
+    const path = repoProps.path as Record<string, unknown>;
+    expect(path.type).toBe("string");
+  });
+
+  it("has a pattern requiring {filePath} placeholder", () => {
+    const path = repoProps.path as Record<string, unknown>;
+    expect(path.pattern).toBe("\\{filePath\\}");
+  });
+
+  it("pattern rejects value without {filePath}", () => {
+    const path = repoProps.path as Record<string, unknown>;
+    const regex = new RegExp(path.pattern as string);
+    expect(regex.test("blob/main/")).toBe(false);
+    expect(regex.test("blob/main")).toBe(false);
+    expect(regex.test("")).toBe(false);
+  });
+
+  it("pattern accepts value with {filePath}", () => {
+    const path = repoProps.path as Record<string, unknown>;
+    const regex = new RegExp(path.pattern as string);
+    expect(regex.test("blob/main/{filePath}")).toBe(true);
+    expect(regex.test("blob/main/apps/web/{filePath}")).toBe(true);
+    expect(regex.test("-/blob/main/{filePath}")).toBe(true);
+    expect(regex.test("src/branch/main/{filePath}")).toBe(true);
+    expect(regex.test("src/main/{filePath}")).toBe(true);
+  });
+
+  it("has examples covering all major platforms", () => {
+    const path = repoProps.path as Record<string, unknown>;
+    const examples = path.examples as string[];
+    expect(examples).toBeDefined();
+    // GitHub
+    expect(examples.some((e) => e.startsWith("blob/main/"))).toBe(true);
+    // GitLab
+    expect(examples.some((e) => e.startsWith("-/blob/main/"))).toBe(true);
+    // Bitbucket
+    expect(examples.some((e) => e.startsWith("src/main/"))).toBe(true);
+    // Gitea/Forgejo
+    expect(examples.some((e) => e.startsWith("src/branch/main/"))).toBe(true);
+    // All examples contain {filePath}
+    expect(examples.every((e) => e.includes("{filePath}"))).toBe(true);
+  });
+
+  it("description mentions {filePath} and auto-detect", () => {
+    const path = repoProps.path as Record<string, unknown>;
+    expect(path.description as string).toContain("{filePath}");
+    expect(path.description as string).toContain("auto-detect");
+  });
+});

--- a/packages/flame/.docu/components/Context.tsx
+++ b/packages/flame/.docu/components/Context.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { cn } from "../node/utils";
 import { Dropdown, DropdownItem } from "@docubook/ui-react/dropdown";
-import { routes } from "../node/client-routes";
+import { routes, config as docuConfig } from "../node/client-routes";
 import { ChevronsUpDown, Check } from "lucide-react";
 import { renderLucideIcon } from "./Lucide";
 
@@ -26,6 +26,9 @@ function getActiveContextRoute(path: string) {
 }
 
 export function Context({ className }: ContextProps) {
+  const mode = docuConfig.sidebar?.context || "dropdown";
+  if (mode === "separator") return null;
+
   const [pathname] = useState(() =>
     typeof window !== "undefined" ? window.location.pathname : "/"
   );

--- a/packages/flame/.docu/components/Context.tsx
+++ b/packages/flame/.docu/components/Context.tsx
@@ -26,13 +26,13 @@ function getActiveContextRoute(path: string) {
 }
 
 export function Context({ className }: ContextProps) {
-  const mode = docuConfig.sidebar?.context || "dropdown";
-  if (mode === "separator") return null;
-
   const [pathname] = useState(() =>
     typeof window !== "undefined" ? window.location.pathname : "/"
   );
   const mounted = typeof window !== "undefined";
+
+  const mode = docuConfig.sidebar?.context || "dropdown";
+  if (mode === "separator") return null;
   const activeRoute = pathname.startsWith("/docs") ? getActiveContextRoute(pathname) : undefined;
   const contextRoutes = getContextRoutes();
   const fallbackRoute = routes[0];

--- a/packages/flame/.docu/components/Menu.tsx
+++ b/packages/flame/.docu/components/Menu.tsx
@@ -40,7 +40,30 @@ export default function Menu({ onNavigate, className = "", pathname, routes = []
   // Separator mode: render all context sections as group headers + nav items
   if (mode === "separator") {
     const contextRoutes = menuRoutes.filter((r) => r.context);
-    if (contextRoutes.length === 0) return null;
+
+    // No context routes defined — fall back to flat list of all routes
+    if (contextRoutes.length === 0) {
+      return (
+        <nav
+          aria-label="Documentation navigation"
+          className={cn("transition-all duration-200", className)}
+        >
+          <ul className="flex flex-col gap-1.5 py-4">
+            {menuRoutes.map((route) => (
+              <li key={route.href}>
+                <Sublink
+                  {...route}
+                  href={route.href}
+                  level={0}
+                  onNavigate={onNavigate}
+                  parentHref="/docs"
+                />
+              </li>
+            ))}
+          </ul>
+        </nav>
+      );
+    }
 
     return (
       <nav
@@ -54,15 +77,17 @@ export default function Menu({ onNavigate, className = "", pathname, routes = []
               title={route.context?.title || route.title}
             />
             <ul className="border-base-300 flex flex-col gap-1.5 border-l-2 pb-0.5 pl-3 pt-0.5">
-              <li>
-                <Sublink
-                  {...route}
-                  href={route.href}
-                  level={0}
-                  onNavigate={onNavigate}
-                  parentHref="/docs"
-                />
-              </li>
+              {route.items?.map((item) => (
+                <li key={item.href}>
+                  <Sublink
+                    {...item}
+                    href={item.href}
+                    level={0}
+                    onNavigate={onNavigate}
+                    parentHref={`/docs${route.href}`}
+                  />
+                </li>
+              ))}
             </ul>
           </div>
         ))}

--- a/packages/flame/.docu/components/Menu.tsx
+++ b/packages/flame/.docu/components/Menu.tsx
@@ -2,8 +2,10 @@
 
 import { useState } from "react";
 import Sublink from "./Sublink";
+import SidebarGroupHeader from "./SidebarGroupHeader";
 import type { DocuRoute } from "../node/types";
 import { cn } from "../node/utils";
+import { config as docuConfig } from "../node/client-routes";
 
 interface MenuProps {
   onNavigate?: () => void;
@@ -33,6 +35,42 @@ export default function Menu({ onNavigate, className = "", pathname, routes = []
 
   if (!currentPath.startsWith("/docs")) return null;
 
+  const mode = docuConfig.sidebar?.context || "dropdown";
+
+  // Separator mode: render all context sections as group headers + nav items
+  if (mode === "separator") {
+    const contextRoutes = menuRoutes.filter((r) => r.context);
+    if (contextRoutes.length === 0) return null;
+
+    return (
+      <nav
+        aria-label="Documentation navigation"
+        className={cn("transition-all duration-200", className)}
+      >
+        {contextRoutes.map((route, i) => (
+          <div key={route.href} className={i > 0 ? "mt-6 lg:mt-8" : ""}>
+            <SidebarGroupHeader
+              icon={route.context?.icon}
+              title={route.context?.title || route.title}
+            />
+            <ul className="flex flex-col gap-1.5 py-4">
+              <li>
+                <Sublink
+                  {...route}
+                  href={route.href}
+                  level={0}
+                  onNavigate={onNavigate}
+                  parentHref="/docs"
+                />
+              </li>
+            </ul>
+          </div>
+        ))}
+      </nav>
+    );
+  }
+
+  // Dropdown mode: render only the active context section
   const isDocsRoot = currentPath === "/docs" || currentPath === "/docs/";
   const currentContext = isDocsRoot
     ? menuRoutes[0]?.href.replace(/^\/+|\/+$/, "")

--- a/packages/flame/.docu/components/Menu.tsx
+++ b/packages/flame/.docu/components/Menu.tsx
@@ -53,7 +53,7 @@ export default function Menu({ onNavigate, className = "", pathname, routes = []
               icon={route.context?.icon}
               title={route.context?.title || route.title}
             />
-            <ul className="flex flex-col gap-1.5 py-4">
+            <ul className="border-base-300 flex flex-col gap-1.5 border-l-2 pb-0.5 pl-3 pt-0.5">
               <li>
                 <Sublink
                   {...route}

--- a/packages/flame/.docu/components/SidebarGroupHeader.tsx
+++ b/packages/flame/.docu/components/SidebarGroupHeader.tsx
@@ -7,7 +7,7 @@ interface SidebarGroupHeaderProps {
 
 export default function SidebarGroupHeader({ icon, title }: SidebarGroupHeaderProps) {
   return (
-    <div className="sidebar-group-header mb-3.5 flex items-center gap-2.5 pl-4 font-medium text-gray-900 lg:mb-2.5 dark:text-gray-200">
+    <div className="sidebar-group-header mb-3.5 flex items-center gap-2.5 font-medium text-gray-900 lg:mb-2.5 dark:text-gray-200">
       {icon && (
         <span className="flex h-4 w-4 shrink-0 items-center justify-center">
           {renderLucideIcon(icon, "h-3.5 w-3.5")}

--- a/packages/flame/.docu/components/SidebarGroupHeader.tsx
+++ b/packages/flame/.docu/components/SidebarGroupHeader.tsx
@@ -7,7 +7,7 @@ interface SidebarGroupHeaderProps {
 
 export default function SidebarGroupHeader({ icon, title }: SidebarGroupHeaderProps) {
   return (
-    <div className="sidebar-group-header mb-3.5 flex items-center gap-2.5 font-medium text-gray-900 lg:mb-2.5 dark:text-gray-200">
+    <div className="sidebar-group-header mb-1.5 flex items-center gap-2.5 font-medium text-gray-900 dark:text-gray-200">
       {icon && (
         <span className="flex h-4 w-4 shrink-0 items-center justify-center">
           {renderLucideIcon(icon, "h-3.5 w-3.5")}

--- a/packages/flame/.docu/components/SidebarGroupHeader.tsx
+++ b/packages/flame/.docu/components/SidebarGroupHeader.tsx
@@ -8,7 +8,11 @@ interface SidebarGroupHeaderProps {
 export default function SidebarGroupHeader({ icon, title }: SidebarGroupHeaderProps) {
   return (
     <div className="sidebar-group-header mb-3.5 flex items-center gap-2.5 pl-4 font-medium text-gray-900 lg:mb-2.5 dark:text-gray-200">
-      {icon && renderLucideIcon(icon, "sidebar-group-icon h-3.5 w-3.5 bg-current")}
+      {icon && (
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+          {renderLucideIcon(icon, "h-3.5 w-3.5")}
+        </span>
+      )}
       <h3 className="sidebar-title font-[inherit] text-[length:inherit] leading-[inherit]">
         <span>{title}</span>
       </h3>

--- a/packages/flame/.docu/components/SidebarGroupHeader.tsx
+++ b/packages/flame/.docu/components/SidebarGroupHeader.tsx
@@ -1,0 +1,17 @@
+import { renderLucideIcon } from "./Lucide";
+
+interface SidebarGroupHeaderProps {
+  icon?: string;
+  title: string;
+}
+
+export default function SidebarGroupHeader({ icon, title }: SidebarGroupHeaderProps) {
+  return (
+    <div className="sidebar-group-header mb-3.5 flex items-center gap-2.5 pl-4 font-medium text-gray-900 lg:mb-2.5 dark:text-gray-200">
+      {icon && renderLucideIcon(icon, "sidebar-group-icon h-3.5 w-3.5 bg-current")}
+      <h3 className="sidebar-title font-[inherit] text-[length:inherit] leading-[inherit]">
+        <span>{title}</span>
+      </h3>
+    </div>
+  );
+}

--- a/packages/flame/.docu/node/client-routes.ts
+++ b/packages/flame/.docu/node/client-routes.ts
@@ -1,5 +1,5 @@
-import type { DocuRoute } from "./types";
+import type { DocuRoute, DocuConfig } from "./types";
 import docuConfig from "../../docu.json" with { type: "json" };
 
 export const routes: DocuRoute[] = docuConfig.routes || [];
-export const config = docuConfig;
+export const config = docuConfig as unknown as DocuConfig;

--- a/packages/flame/.docu/node/helpers.ts
+++ b/packages/flame/.docu/node/helpers.ts
@@ -4,9 +4,30 @@ import type { SocialLink } from "./types";
 const docuConfig = loadDocuConfig();
 
 export function getEditLink(url: string, filePath: string): string {
-  const configPath = docuConfig?.repo?.path || "blob/main/{filePath}";
+  const configPath = docuConfig?.repo?.path || detectPlatformPath(url);
   const encodedPath = filePath.replace(/^\//, "").split("/").map(encodeURIComponent).join("/");
   return `${url}/${configPath}`.replace("{filePath}", encodedPath);
+}
+
+/**
+ * Detect the default edit path template from the repo URL hostname.
+ * Supports GitHub, GitLab, Bitbucket, Gitea (cloud + self-hosted),
+ * Gogs, Forgejo, and Codeberg.
+ * Falls back to Gitea-style for unknown hosts — override via repo.path.
+ */
+export function detectPlatformPath(url: string): string {
+  try {
+    const host = new URL(url).hostname;
+    if (host === "github.com") return "blob/main/{filePath}";
+    if (host === "gitlab.com") return "-/blob/main/{filePath}";
+    if (host === "bitbucket.org") return "src/main/{filePath}";
+    if (host === "gitea.com") return "src/branch/main/{filePath}";
+    if (host === "codeberg.org") return "src/branch/main/{filePath}";
+    // Gogs, Forgejo, or any self-hosted Gitea-compatible forge
+    return "src/branch/main/{filePath}";
+  } catch {
+    return "blob/main/{filePath}";
+  }
 }
 
 export function isEditEnabled(): boolean {

--- a/packages/flame/.docu/node/types.ts
+++ b/packages/flame/.docu/node/types.ts
@@ -34,6 +34,13 @@ export interface DocuFooter {
   social: SocialLink[];
 }
 
+export interface DocuSidebar {
+  /** How context sections are displayed.
+   *  "dropdown" — context switcher dropdown (default)
+   *  "separator" — inline group headers in sidebar */
+  context?: "dropdown" | "separator";
+}
+
 export interface RepoConfig {
   url: string;
   path: string;
@@ -75,6 +82,7 @@ export interface DocuConfig {
   navbar: DocuNavbar;
   footer: DocuFooter;
   repo: RepoConfig;
+  sidebar?: DocuSidebar;
   routes: DocuRoute[];
   themes?: {
     colors: ThemeConfig;

--- a/packages/flame/README.md
+++ b/packages/flame/README.md
@@ -212,6 +212,57 @@ Theme resolution follows this order (first match wins):
 
 ---
 
+### Sidebar
+
+Configure sidebar behavior with the `sidebar` object. Currently supports one option — context mode.
+
+```json
+{
+  "sidebar": {
+    "context": "separator"
+  }
+}
+```
+
+#### Context Mode
+
+Controls how documentation sections (routes with a `context` property) appear in the sidebar.
+
+| Mode | Description |
+|------|-------------|
+| `"dropdown"` (default) | A dropdown at the top of the sidebar lets users switch between sections. Only the active section's items are shown. |
+| `"separator"` | All sections render inline with a group header (icon + title) and a tree connector line. Items appear nested under their section. |
+
+**Dropdown mode** — compact, one section at a time:
+
+```
+┌──────────────────────┐
+│  📖 Guides     ▼     │  ← context switcher
+├──────────────────────┤
+│  Introduction        │
+│  Installation        │
+└──────────────────────┘
+```
+
+**Separator mode** — all sections visible with tree lines:
+
+```
+📖 Guides              
+│                      
+├─ Introduction        
+├─ Installation        
+│                      
+🧩 Markdown            
+│                      
+├─ Accordion           
+├─ Button              
+└─ Card                
+```
+
+> Omit `sidebar` or set `sidebar.context` to `"dropdown"` for the default behavior. The mode is static per page — no runtime switching.
+
+---
+
 ### Routes
 
 When `routes` is an empty array `[]`, Flame automatically scans your `docs/` folder at build-time and generates the sidebar navigation from the directory structure. Folders become collapsible sections, and `.mdx`/`.md` files become links — sorted alphabetically.
@@ -240,6 +291,8 @@ To define navigation manually, populate the `routes` array:
 ```
 
 > Manual routes take priority — if `routes` has entries, folder scanning is skipped entirely.
+
+> Context on a route (`icon`, `title`, `description`) provides metadata for the sidebar context switcher. In **dropdown** mode it fills the dropdown; in **separator** mode it renders the group header + tree. The icon name must match a [Lucide icon](https://lucide.dev/icons) export (e.g., `"BookOpen"`, `"Layers"`).
 
 ---
 

--- a/packages/flame/README.md
+++ b/packages/flame/README.md
@@ -214,7 +214,9 @@ Theme resolution follows this order (first match wins):
 
 ### Sidebar
 
-Configure sidebar behavior with the `sidebar` object. Currently supports one option — context mode.
+Controls how documentation sections appear in the sidebar. Defaults to **dropdown** mode when not configured.
+
+To switch to **separator** mode, add `sidebar` to the top level of your `docu.json`:
 
 ```json
 {
@@ -224,42 +226,26 @@ Configure sidebar behavior with the `sidebar` object. Currently supports one opt
 }
 ```
 
-#### Context Mode
-
-Controls how documentation sections (routes with a `context` property) appear in the sidebar.
-
 | Mode | Description |
 |------|-------------|
-| `"dropdown"` (default) | A dropdown at the top of the sidebar lets users switch between sections. Only the active section's items are shown. |
-| `"separator"` | All sections render inline with a group header (icon + title) and a tree connector line. Items appear nested under their section. |
-
-**Dropdown mode** — compact, one section at a time:
+| `"dropdown"` (default) | Compact view — a dropdown at the top of the sidebar lets users switch between sections. Only the active section's items are shown. |
+| `"separator"` | All sections visible — group header (icon + title) with tree connector line. Items nest under their section. |
 
 ```
-┌──────────────────────┐
-│  📖 Guides     ▼     │  ← context switcher
-├──────────────────────┤
-│  Introduction        │
-│  Installation        │
-└──────────────────────┘
+  Default (dropdown)              Separator
+  ┌──────────────────┐       📖 Guides
+  │  📖 Guides  ▼    │       │
+  ├──────────────────┤       ├─ Introduction
+  │  Introduction    │       ├─ Installation
+  │  Installation    │       │
+  └──────────────────┘       🧩 Markdown
+                              │
+                              ├─ Accordion
+                              ├─ Button
+                              └─ Card
 ```
 
-**Separator mode** — all sections visible with tree lines:
-
-```
-📖 Guides              
-│                      
-├─ Introduction        
-├─ Installation        
-│                      
-🧩 Markdown            
-│                      
-├─ Accordion           
-├─ Button              
-└─ Card                
-```
-
-> Omit `sidebar` or set `sidebar.context` to `"dropdown"` for the default behavior. The mode is static per page — no runtime switching.
+> Omit `sidebar` entirely → dropdown mode. Set `"context": "separator"` → separator mode. Mode is static per page, no runtime switching.
 
 ---
 

--- a/packages/flame/README.md
+++ b/packages/flame/README.md
@@ -105,14 +105,91 @@ bun run deploy    # Build + prepare for GitHub Pages
   },
   "repo": {
     "url": "https://github.com/you/repo",
-    "path": "blob/main/{filePath}",
     "edit": true
   },
   "routes": []
 }
 ```
 
-### Home Page
+### Repo & Edit Links
+
+The `repo` section enables **"Edit this page"** links on every doc page, pointing directly to the source file in your repository.
+
+```json
+{
+  "repo": {
+    "url": "https://github.com/you/repo",
+    "edit": true
+  }
+}
+```
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | `string` (URI) | ✅ Yes | Base URL of your repository |
+| `edit` | `boolean` | ✅ Yes | Show or hide the edit link on pages |
+| `path` | `string` | No | Path template override — see below |
+
+#### Platform Auto-Detection
+
+When `path` is omitted, Flame detects the correct path format from `url` automatically:
+
+| Platform | Domain | Auto-generated path |
+|----------|--------|---------------------|
+| GitHub | `github.com` | `blob/main/{filePath}` |
+| GitLab | `gitlab.com` | `-/blob/main/{filePath}` |
+| Bitbucket | `bitbucket.org` | `src/main/{filePath}` |
+| Gitea Cloud | `gitea.com` | `src/branch/main/{filePath}` |
+| Codeberg (Forgejo) | `codeberg.org` | `src/branch/main/{filePath}` |
+| Gogs / self-hosted Gitea / Forgejo | any other host | `src/branch/main/{filePath}` |
+
+For most single-repo projects this is all you need — just set `url` and `edit: true`.
+
+#### When to set `path` manually
+
+Override `path` when auto-detection is not enough. The value must contain `{filePath}` as a placeholder:
+
+**Monorepo** — docs live in a subdirectory, not the repo root:
+
+```json
+{
+  "repo": {
+    "url": "https://github.com/org/monorepo",
+    "path": "blob/main/apps/docs/{filePath}",
+    "edit": true
+  }
+}
+```
+
+**Non-default branch** — your default branch is not `main`:
+
+```json
+{
+  "repo": {
+    "url": "https://github.com/you/repo",
+    "path": "blob/master/{filePath}",
+    "edit": true
+  }
+}
+```
+
+**Self-hosted GitLab on a custom domain** — auto-detect falls back to Gitea format, which is wrong for GitLab:
+
+```json
+{
+  "repo": {
+    "url": "https://git.mycompany.com/team/repo",
+    "path": "-/blob/main/{filePath}",
+    "edit": true
+  }
+}
+```
+
+> **Rule of thumb:** if your docs are at the root of the repo and the branch is `main`, skip `path` — auto-detect handles it. Add `path` only when you need to point to a subdirectory, a different branch, or a self-hosted platform with a non-standard URL format.
+
+
+
+### Homepage
 
 The `home` section configures your landing page with a hero section and feature cards:
 

--- a/packages/flame/docu.json
+++ b/packages/flame/docu.json
@@ -6,6 +6,9 @@
     "baseURL": "https://docubook.pro",
     "favicon": "/docs/assets/images/favicon.ico"
   },
+  "sidebar": {
+    "context": "separator"
+  },
   "themes": {
     "colors": "default"
   },

--- a/packages/flame/docu.schema.json
+++ b/packages/flame/docu.schema.json
@@ -105,10 +105,32 @@
       "description": "Repository configuration for edit links",
       "additionalProperties": false,
       "properties": {
-        "url": { "type": "string", "description": "Repository URL" },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Repository base URL. Supported platforms: GitHub, GitLab, Bitbucket, Gitea (gitea.com), Codeberg (codeberg.org), Gogs, Forgejo, or any self-hosted Gitea-compatible forge.",
+          "examples": [
+            "https://github.com/owner/repo",
+            "https://gitlab.com/owner/repo",
+            "https://bitbucket.org/owner/repo",
+            "https://gitea.com/owner/repo",
+            "https://codeberg.org/owner/repo"
+          ]
+        },
         "path": {
           "type": "string",
-          "description": "Path template for edit links. Use {filePath} as placeholder."
+          "description": "Path template for edit links. Must contain {filePath} as a placeholder. Format: {platform-path}/{optional-subdir}/{filePath}. Leave empty to auto-detect from repo.url hostname.",
+          "pattern": "\\{filePath\\}",
+          "examples": [
+            "blob/main/{filePath}",
+            "blob/main/apps/web/{filePath}",
+            "blob/develop/{filePath}",
+            "-/blob/main/{filePath}",
+            "-/blob/main/docs/{filePath}",
+            "src/main/{filePath}",
+            "src/branch/main/{filePath}",
+            "src/branch/main/docs/{filePath}"
+          ]
         },
         "edit": { "type": "boolean", "description": "Enable edit link on pages" }
       }

--- a/packages/flame/docu.schema.json
+++ b/packages/flame/docu.schema.json
@@ -113,6 +113,19 @@
         "edit": { "type": "boolean", "description": "Enable edit link on pages" }
       }
     },
+    "sidebar": {
+      "type": "object",
+      "description": "Sidebar configuration",
+      "additionalProperties": false,
+      "properties": {
+        "context": {
+          "type": "string",
+          "enum": ["dropdown", "separator"],
+          "default": "dropdown",
+          "description": "How context sections are displayed in sidebar — dropdown (switcher) or separator (inline group headers)"
+        }
+      }
+    },
     "routes": {
       "type": "array",
       "description": "Documentation navigation routes. Leave empty for auto-detection from docs/ folder.",


### PR DESCRIPTION
feature request from @dwindiramadhana

## Summary

Add `sidebar.context` configuration to **@docubook/flame** with two modes — **"dropdown"** (default) and **"separator"** — giving docs authors control over how context sections render in the sidebar.

**Dropdown mode** (default, backward compatible): a dropdown at the top of the sidebar lets users switch between sections. Only the active section's items are shown.

**Separator mode**: all sections render inline with a group header (icon + title) and a tree connector line. Items nest under their section.

```
  Default (dropdown)              Separator
  ┌──────────────────┐       📖 Guides
  │  📖 Guides  ▼    │       │
  ├──────────────────┤       ├─ Introduction
  │  Introduction    │       ├─ Installation
  │  Installation    │       │
  └──────────────────┘       🧩 Markdown
                              │
                              ├─ Accordion
                              ├─ Button
                              └─ Card
```
---

## Screenshots

<img width="287" height="1337" alt="image" src="https://github.com/user-attachments/assets/1e34173c-5b56-4d1c-b6ea-5fc728d44e16" />

<img width="1280" height="250" alt="telegram-cloud-photo-size-5-6208574320037008500-y" src="https://github.com/user-attachments/assets/4c42961c-777c-44d1-a470-e49176029f74" />


## Commits

### Schema & Types

| Commit | Description |
|--------|-------------|
| [`5892828`](https://github.com/DocuBook/docubook/commit/5892828aec29a66f44d56b01a5e4ce290cb46fba) | Add `sidebar` object to `docu.schema.json` with `context` enum (`"dropdown"` / `"separator"`), default `"dropdown"`. Add `DocuSidebar` interface + optional `sidebar` field to `DocuConfig` in `types.ts`. |

### Separator Mode Components

| Commit | Description |
|--------|-------------|
| [`a51d34e`](https://github.com/DocuBook/docubook/commit/a51d34efeadae3b18b1b2b095d10bd59da101b0b) | Create `SidebarGroupHeader.tsx` — presentational component (Lucide icon + title) with zero state/events. |
| [`b5f1c78`](https://github.com/DocuBook/docubook/commit/b5f1c7835101aafc0c0af58903e1a6e3c58f0570) | Add guard in `Context.tsx` — return `null` when `sidebar.context === "separator"`. |
| [`b6bba8c`](https://github.com/DocuBook/docubook/commit/b6bba8cc33a3f5055b73d88240ad5fbc3c2c144c) | Add separator mode branch in `Menu.tsx` — renders all context sections with `SidebarGroupHeader` + `Sublink`. Dropdown mode unchanged. |
| [`1666aa9`](https://github.com/DocuBook/docubook/commit/1666aa9dcffe7705c253e376495e36b5e7a083b9) | Fix React hooks ordering in `Context.tsx` (`useState` before conditional return) to comply with `react-hooks/rules-of-hooks`. |

### Visual Polish

| Commit | Description |
|--------|-------------|
| [`3bf3ccf`](https://github.com/DocuBook/docubook/commit/3bf3ccfddd704c2c51622b480eec9929418de712) | Wrap `SidebarGroupHeader` icon in styled `<span>` (matching `Context.tsx` pattern). Remove `bg-current` — Lucide uses stroke, not fill. |
| [`9023c09`](https://github.com/DocuBook/docubook/commit/9023c093047bb6a4e6832659d2b38cebd9c4017a) | Align `SidebarGroupHeader` padding with level-0 Sublink items (remove `pl-4`, flush with container `px-4`). |
| [`51fb43b`](https://github.com/DocuBook/docubook/commit/51fb43b857de73a2f3e84b677954c4ab959bed78) | Tighten header→items spacing (`mb-3.5` → `mb-1.5`). Add tree connector (`border-l-2` + `pl-3` on `<ul>`). |

### Tests

| Commit | Description |
|--------|-------------|
| [`51e0213`](https://github.com/DocuBook/docubook/commit/51e0213f381dd744cb277cb02f9a63d47b0af4ec) | Add 5 schema validation tests for `sidebar` property (exists, type object, enum values, default, no additional properties). |

### Build Fix

| Commit | Description |
|--------|-------------|
| [`60b99ae`](https://github.com/DocuBook/docubook/commit/60b99ae9c90a24099ba14cf09e6938c411d6992f) | Fix pre-existing SSR build error (`ReactSharedInternals.H` null) — sync `apps/web` React version from `19.2.3` to `^19.2.7` to match workspace override. Removed stale `overrides` block. |

### Documentation

| Commit | Description |
|--------|-------------|
| [`d65f3af`](https://github.com/DocuBook/docubook/commit/d65f3af1cd113ea165e5e6ffd181a985013a5ed3) | Add Sidebar section to README with default dropdown + separator mode docs, side-by-side ASCII diagram, and Lucide icon reference. |
| [`6701908`](https://github.com/DocuBook/docubook/commit/670190891d0d019cd8b794e0863e017d0a30f88f) | Add changeset `@docubook/flame: minor`. |

---

## Files Changed

```
.changeset/eleven-spoons-live.md                    (new)
apps/web/package.json                               (modified)
packages/flame/.docu/__tests__/schema.test.ts       (modified)
packages/flame/.docu/components/Context.tsx          (modified)
packages/flame/.docu/components/Menu.tsx             (modified)
packages/flame/.docu/components/SidebarGroupHeader.tsx (new)
packages/flame/.docu/node/types.ts                   (modified)
packages/flame/README.md                             (modified)
packages/flame/docu.schema.json                      (modified)
```

---

## Verification

- ✅ 291 tests pass (286 existing + 5 new)
- ✅ ESLint: 0 errors
- ✅ Build: 28 pages (0 errors)
- ✅ Backward compatible: absent `sidebar` → dropdown mode (unchanged)
- ✅ Sublink.tsx behavior untouched