### PR TITLE
chore: add flame init test script

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -28,3 +28,5 @@ jobs:
         uses: pullfrog/pullfrog@v0
         with:
           prompt: ${{ inputs.prompt }}
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ Thumbs.db
 .temp
 .tmp
 
+# Dev-only test script (runtime compatibility)
+test-flame-init.mjs
+
 # System
 *.pem
 *.p12


### PR DESCRIPTION
Wires `OPENCODE_API_KEY` into the pullfrog workflow and gitignores a dev-only test script.

- Add `OPENCODE_API_KEY` env to `pullfrog.yml` — needed by the pullfrog agent to authenticate with the opencode model
- Gitignore `test-flame-init.mjs` — local runtime-compatibility test script (not committed, dev-only)