### PR TITLE
fix: clamp saturation values with Math.max in dark mode

### DIFF
--- a/.changeset/seven-turtles-wonder.md
+++ b/.changeset/seven-turtles-wonder.md
@@ -1,0 +1,7 @@
+---
+'@docubook/themes-colors': patch
+---
+
+Fix saturation clamping in `generateScale` dark mode
+
+Three template literals in dark mode (`foreground`, `card-foreground`, `popover-foreground`) used `primaryS - 10` without `Math.max`, producing negative saturation values when `primaryS < 10`. Wrapped all `primaryS - N` expressions with `Math.max` to ensure valid CSS output.

--- a/packages/themes-colors/src/hex-to-hsl.ts
+++ b/packages/themes-colors/src/hex-to-hsl.ts
@@ -214,11 +214,11 @@ export function generateScale(primary: HslColor): {
   // Dark mode — invert the lightness scale
   const dark: Record<string, string> = {
     background: `${h} ${Math.max(primaryS - 40, 5)}% 11%`,
-    foreground: `${h} ${primaryS - 10}% 93%`,
+    foreground: `${h} ${Math.max(primaryS - 10, 5)}% 93%`,
     card: `${h} ${Math.max(primaryS - 40, 5)}% 14%`,
-    "card-foreground": `${h} ${primaryS - 10}% 93%`,
+    "card-foreground": `${h} ${Math.max(primaryS - 10, 5)}% 93%`,
     popover: `${h} ${Math.max(primaryS - 40, 5)}% 14%`,
-    "popover-foreground": `${h} ${primaryS - 10}% 93%`,
+    "popover-foreground": `${h} ${Math.max(primaryS - 10, 5)}% 93%`,
     primary: `${h} ${primaryS + 10}% 67%`,
     "primary-foreground": `${h} ${Math.max(primaryS - 20, 5)}% 11%`,
     secondary: `${h + 10} ${Math.max(primaryS - 50, 5)}% 18%`,


### PR DESCRIPTION
Three dark mode template literals (foreground, card-foreground,
popover-foreground) used primaryS - 10 without clamping, producing
negative saturation when primaryS < 10.
