### PR TITLE
fix(flame): make githublink respect repo.edit flag to hide github icon

### DIFF
--- a/.changeset/loud-balloons-jump.md
+++ b/.changeset/loud-balloons-jump.md
@@ -1,0 +1,9 @@
+---
+'@docubook/flame': patch
+---
+
+GitHubLink: respect repo.edit flag to hide GitHub icon when edit is disabled
+
+`GitHubLink` component previously only checked whether a `repoUrl` prop was provided. When `repo.edit` was set to `false` in `docu.json`, the "Edit this page" link correctly disappeared, but the GitHub icon in the sidebar remained visible because `GitHubLink` was unaware of the edit flag.
+
+Now `GitHubLink` also checks `docuConfig.repo?.edit`, so both the edit link and GitHub icon are consistently hidden when editing is disabled.

--- a/packages/flame/.docu/components/Navbar.tsx
+++ b/packages/flame/.docu/components/Navbar.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { useState } from "react";
 import Anchor from "./Anchor";
 import { cn } from "../node/utils";
+import { config as docuConfig } from "../node/client-routes";
 import {
   Navbar as BaseNavbar,
   Logo as BaseLogo,
@@ -172,7 +173,7 @@ export function NavbarBrand({
 }
 
 export function GitHubLink({ repoUrl }: { repoUrl?: string }) {
-  if (!repoUrl) return null;
+  if (!docuConfig.repo?.edit || !repoUrl) return null;
 
   return (
     <a


### PR DESCRIPTION
## Changes

`GitHubLink` component previously only checked whether a `repoUrl` prop was provided. When `repo.edit` was set to `false` in `docu.json`, the "Edit this page" link (via `EditWith`) correctly disappeared, but the GitHub icon in the sidebar remained visible because `GitHubLink` was unaware of the edit flag.

Now `GitHubLink` also checks `docuConfig.repo?.edit`, so both the edit link and GitHub icon are consistently hidden when editing is disabled.

### Files changed
| File | Changes |
|------|---------|
| `Navbar.tsx` | Added `docuConfig` import from `client-routes`, `GitHubLink` now checks `docuConfig.repo?.edit \|\| !repoUrl` |
| `.changeset/loud-balloons-jump.md` | Patch changeset for `@docubook/flame` |