### PR TITLE
Sync CSP to all serving layers; remove USER nginx from Dockerfile template

### DIFF
--- a/.changeset/tiny-donuts-fly.md
+++ b/.changeset/tiny-donuts-fly.md
@@ -1,0 +1,11 @@
+---
+'@docubook/flame': patch
+---
+
+Remove `USER nginx` from Dockerfile template to prevent container crash
+
+The `USER nginx` directive causes nginx to fail creating cache directories
+(`/var/cache/nginx/client_temp`) with permission denied, killing the
+container immediately. Since the container only serves static HTML, no
+cache directories are needed — removing the directive lets the container
+run as root (default) while nginx worker processes still run as `nginx`.

--- a/packages/flame/.docu/__tests__/deploy.test.ts
+++ b/packages/flame/.docu/__tests__/deploy.test.ts
@@ -33,6 +33,7 @@ describe("deploy Docker — generated file content", () => {
     expect(NGINX_CONF).toContain(
       'add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always'
     );
+    expect(NGINX_CONF).toContain('add_header Content-Security-Policy "default-src');
   });
 
   it("NGINX_CONF /assets/ uses 1y immutable cache", () => {
@@ -58,6 +59,12 @@ describe("deploy Docker — generated file content", () => {
     expect(HEADERS_FILE).toContain("/assets/*");
     expect(HEADERS_FILE).toContain("Cache-Control: public, max-age=31536000, immutable");
     expect(HEADERS_FILE).not.toContain("/assets/chunks/*");
+  });
+
+  it("_headers includes CSP and security headers", () => {
+    expect(HEADERS_FILE).toContain("Content-Security-Policy: default-src");
+    expect(HEADERS_FILE).toContain("Strict-Transport-Security:");
+    expect(HEADERS_FILE).toContain("Permissions-Policy:");
   });
 });
 

--- a/packages/flame/.docu/node/deploy.shared.ts
+++ b/packages/flame/.docu/node/deploy.shared.ts
@@ -31,6 +31,7 @@ export const NGINX_CONF = `server {
   add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
   add_header Referrer-Policy "strict-origin-when-cross-origin" always;
   add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'" always;
 
   location /assets/ {
     expires 1y;
@@ -40,6 +41,7 @@ export const NGINX_CONF = `server {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'" always;
   }
 
   location /docs/assets/ {
@@ -50,6 +52,7 @@ export const NGINX_CONF = `server {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'" always;
   }
 
   location / {
@@ -126,7 +129,10 @@ export function detectPkgManager(dir: string): {
 export const HEADERS_FILE = `/*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/packages/flame/.docu/node/deploy.shared.ts
+++ b/packages/flame/.docu/node/deploy.shared.ts
@@ -172,7 +172,6 @@ RUN ${pm.runCmd} run build
 FROM nginx:alpine
 COPY --from=builder /app/.docu/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-USER nginx
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
 `

--- a/packages/flame/.docu/node/deploy.ts
+++ b/packages/flame/.docu/node/deploy.ts
@@ -53,7 +53,6 @@ RUN bun run build
 FROM nginx:alpine
 COPY --from=builder /app/.docu/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-USER nginx
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
 `;


### PR DESCRIPTION
## PR #322 — Deployment fixes

### 1. Remove `USER nginx` from Dockerfile template
`USER nginx` causes permission denied on `/var/cache/nginx/client_temp` because nginx cannot create cache directories as non-root user. Container only serves static HTML — no cache needed.

### 2. Sync CSP to NGINX_CONF and HEADERS_FILE
CSP was only defined in `vercel.json` (Vercel deploy). `NGINX_CONF` (Docker nginx) and `HEADERS_FILE` (Netlify/Cloudflare) had **no CSP** despite ARCHITECTURE.md stating "CSP always comes from the serving layer."

Now all serving layers have the same CSP:
```
default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https:; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'
```

Also added missing HSTS and Permissions-Policy to `HEADERS_FILE` to match the other layers.

### Verification
- Test: ✅ 436 passed (20 files)
- All CSP locations: 4 (nginx root, /assets/, /docs/assets/, _headers)