### PR TITLE
fix(flame): fix Docker build JSX crash and missing git

### DIFF
--- a/.changeset/curly-frogs-walk.md
+++ b/.changeset/curly-frogs-walk.md
@@ -1,0 +1,27 @@
+---
+'@docubook/flame': patch
+---
+
+Fix Docker build: JSX runtime crash and missing git
+
+Two issues on Coolify/Docker deployment using `oven/bun:1`:
+
+1. **JSX runtime crash:** Bun v1.3.14 reads `NODE_ENV` at startup to select the JSX
+   transform (`jsxDEV()` for dev, `jsx()` for production). Setting
+   `process.env.NODE_ENV` programmatically in the CLI is too late — Bun has already
+   initialized the JSX runtime. Fix: set `ENV NODE_ENV=production` in the Dockerfile
+   and restore the `NODE_ENV=production` shell prefix in the project template so Bun
+   sees it before startup.
+
+2. **Git not found:** `oven/bun:1` (Alpine) does not include git, which flame needs
+   for file timestamps. Fix: switch base image to `oven/bun:1-debian` (Debian-based)
+   which includes git and has a more compatible glibc for native binaries like esbuild.
+
+Changes:
+- `deploy.shared.ts`: `ENV NODE_ENV=production` in Dockerfile template
+- `deploy.ts`: same in DOCKERFILE_BUN template
+- `deploy.shared.ts`: `oven/bun:1` → `oven/bun:1-debian`
+- `deploy.ts`: `oven/bun:1` → `oven/bun:1-debian`
+- `deploy.test.ts`: update assertions for `1-debian`
+- `template/package.json`: restore `NODE_ENV=production` prefix on build/preview/deploy
+- `bin/cli.js`: restore `NODE_ENV=production` prefix for Deno scaffold

--- a/packages/flame/.docu/__tests__/deploy.test.ts
+++ b/packages/flame/.docu/__tests__/deploy.test.ts
@@ -6,8 +6,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 describe("deploy Docker — generated file content", () => {
-  it("Dockerfile uses oven/bun:1 for Bun path", () => {
-    expect(DOCKERFILE_BUN).toContain("oven/bun:1");
+  it("Dockerfile uses oven/bun:1-debian for Bun path", () => {
+    expect(DOCKERFILE_BUN).toContain("oven/bun:1-debian");
     expect(DOCKERFILE_BUN).toContain("nginx:alpine");
     expect(DOCKERFILE_BUN).toContain("bun.lock");
   });
@@ -93,7 +93,7 @@ describe("detectPkgManager — lockfile detection", () => {
     const pm = detectPkgManager(tmpDir);
     expect(pm.runCmd).toBe("bun");
     expect(pm.lockFile).toBe("bun.lock");
-    expect(pm.baseImage).toBe("oven/bun:1");
+    expect(pm.baseImage).toBe("oven/bun:1-debian");
     expect(pm.installCmd).toBe("bun install --frozen-lockfile");
     expect(pm.cache).toBe("");
     expect(pm.setupAction).toBe("bun");
@@ -105,7 +105,7 @@ describe("detectPkgManager — lockfile detection", () => {
     const pm = detectPkgManager(tmpDir);
     expect(pm.runCmd).toBe("bun");
     expect(pm.lockFile).toBe("bun.lockb");
-    expect(pm.baseImage).toBe("oven/bun:1");
+    expect(pm.baseImage).toBe("oven/bun:1-debian");
     expect(pm.installCmd).toBe("bun install --frozen-lockfile");
     expect(pm.cache).toBe("");
     expect(pm.setupAction).toBe("bun");

--- a/packages/flame/.docu/node/deploy.shared.ts
+++ b/packages/flame/.docu/node/deploy.shared.ts
@@ -87,7 +87,7 @@ export function detectPkgManager(dir: string): {
       : null;
   if (bunLockFile) {
     return {
-      baseImage: "oven/bun:1",
+      baseImage: "oven/bun:1-debian",
       lockFile: bunLockFile,
       installCmd: "bun install --frozen-lockfile",
       runCmd: "bun",
@@ -169,6 +169,7 @@ async function writeDockerFiles() {
     await writeFile(
       join(dockerDir, "Dockerfile"),
       `FROM ${pm.baseImage} AS builder
+ENV NODE_ENV=production
 WORKDIR /app
 COPY package.json ${pm.lockFile} ./
 RUN ${pm.installCmd}

--- a/packages/flame/.docu/node/deploy.ts
+++ b/packages/flame/.docu/node/deploy.ts
@@ -43,7 +43,8 @@ async function runBuild() {
   }
 }
 
-export const DOCKERFILE_BUN = `FROM oven/bun:1 AS builder
+export const DOCKERFILE_BUN = `FROM oven/bun:1-debian AS builder
+ENV NODE_ENV=production
 WORKDIR /app
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile

--- a/packages/flame/bin/cli.js
+++ b/packages/flame/bin/cli.js
@@ -126,9 +126,9 @@ if (command === "init") {
       const flameCmd = "deno run -A npm:@docubook/flame";
       pkg.scripts = {
         dev: `${flameCmd} dev`,
-        build: `${flameCmd} build`,
-        preview: `${flameCmd} preview`,
-        deploy: `${flameCmd} deploy`,
+        build: `NODE_ENV=production ${flameCmd} build`,
+        preview: `NODE_ENV=production ${flameCmd} preview`,
+        deploy: `NODE_ENV=production ${flameCmd} deploy`,
       };
 
       // Generate deno.json with nodeModulesDir for npm compat.

--- a/packages/flame/template/package.json
+++ b/packages/flame/template/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "scripts": {
     "dev": "flame dev",
-    "build": "flame build",
-    "preview": "flame preview",
-    "deploy": "flame deploy"
+    "build": "NODE_ENV=production flame build",
+    "preview": "NODE_ENV=production flame preview",
+    "deploy": "NODE_ENV=production flame deploy"
   },
   "dependencies": {
     "@docubook/flame": "latest"


### PR DESCRIPTION
## Problem

Two issues in Coolify/Docker deployment:

### 1. JSX runtime crash (build fails completely)
```
TypeError: jsxDEV_7x81h0kn is not a function
```
Bun v1.3.14 reads `NODE_ENV` at startup to select the JSX transform (`jsxDEV()` for dev, `jsx()` for production). The CLI guard (`cli.js:71`) sets `NODE_ENV` programmatically — **too late**, Bun has already selected `jsxDEV()`. In React production, `jsxDEV` does not exist → crash.

### 2. Git not found (non-fatal warning)
```
error: Executable not found in PATH: "git"
```
`oven/bun:1` (Alpine) minimalist — does not include git. Flame needs git for timestamps files.

##Fixed

### Fix 1: NODE_ENV before Bun startup
3 layers of defense:

| Layers | Files | How to | Effects |
|-------|------|------|------|
| **Dockerfile** | `deploy.shared.ts` / `deploy.ts` | `ENV NODE_ENV=production` | ✅ Bun see NODE_ENV on startup in Docker |
| **Templates** | `template/package.json` | `NODE_ENV=production flame build` | ✅ New projects from `flame init` |
| **CLI** | `bin/cli.js` | `process.env.NODE_ENV = "production"` | ✅ Bundle size (redundant for JSX) |

### Fix 2: Base image → Debian
`oven/bun:1` → `oven/bun:1-debian` — includes git + glibc (esbuild native binary compatible).

## Verification
- Test: ✅ 437 passes (20 files)
- JSX with `NODE_ENV=production` shell env: ✅ no jsxDEV crashes
- Client bundle: ✅ compiled