### PR TITLE
docs(flame): update docs for Docker deploy and NODE_ENV=production

### DIFF
--- a/packages/flame/docs/getting-started/configuration.mdx
+++ b/packages/flame/docs/getting-started/configuration.mdx
@@ -62,6 +62,7 @@ Site-wide metadata used for page `<title>`, `<meta name="description">`, Open Gr
 | `description` | string | No       | Site description for SEO                                     |
 | `baseURL`     | string | No       | Canonical URL for sitemaps and RSS                           |
 | `favicon`     | string | No       | Path to favicon (default: `/docs/assets/images/favicon.ico`) |
+| `ogImage`     | string | No       | Global fallback OG image URL for social sharing (per-page override via frontmatter `image` field) |
 
 ## navbar
 

--- a/packages/flame/docs/getting-started/deployment.mdx
+++ b/packages/flame/docs/getting-started/deployment.mdx
@@ -30,6 +30,7 @@ Whether the `.html` suffix stays visible in the browser address bar depends on y
 | Azure Static Web Apps | Yes        | Native GitHub       | Azure infra       | `staticwebapp.config.json`     |
 | Render                | Yes        | Native GitHub       | nginx             | Dashboard rewrite rule         |
 | Heroku                | Yes        | Native GitHub       | nginx             | Static buildpack + `static.json` |
+| **Docker**            | **Yes**    | **Any CI/CD**       | **nginx**         | **`flame deploy --docker`**    |
 | GitHub Pages          | No         | Native GitHub       | Apache            | Not supported                  |
 | AWS S3 + CloudFront   | Limited    | GitHub Action       | nginx (CloudFront)| CloudFront Function required   |
 
@@ -164,6 +165,19 @@ GitHub Pages serves files at their exact path only: `/docs/page.html` works, `/d
 Flame ships a deploy helper — `flame deploy` (or `bun run deploy` / `npm run deploy` / `deno task deploy`) builds the site, adds a `.nojekyll` file, and generates a `.github/workflows/deploy.yml` workflow if one does not exist. The generated workflow automatically builds and deploys on every push to the default branch. The `.html` suffix remaining in the address bar is the only limitation — the site itself works perfectly.
 
 Source: [GitHub Pages documentation](https://docs.github.com/en/pages)
+
+### Docker
+
+```shell
+flame deploy --docker
+```
+
+Generates `Dockerfile` + `nginx.conf` + `.dockerignore`. Build and run:
+
+```shell
+docker build -t my-docs .
+docker run -p 80:80 my-docs
+```
 
 ### AWS S3 + CloudFront
 

--- a/packages/flame/docs/getting-started/frontmatter.mdx
+++ b/packages/flame/docs/getting-started/frontmatter.mdx
@@ -22,8 +22,30 @@ Below is a table of available frontmatter fields for documentation pages:
 | ----------- | ------------ | -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | title       | string       | Yes      | The page title, displayed in the header and metadata. |
 | description | string       | Yes      | A short description of the page, used for SEO and previews. |
-| image       | string (URL) | No       | URL for the Open Graph image (`og:image`), used when sharing the page on social media. |
+| image       | string (URL) | No       | Per-page OG image (`og:image`) for social sharing. Falls back to `meta.ogImage` in `docu.json`. See examples below for accepted path formats. |
 | date        | string       | No       | Publication date in `YYYY-MM-DD` format (e.g. `2026-06-10`). If omitted, the file's last modified time is used automatically. |
+
+### Image path examples
+
+```yaml
+# Absolute URL — always works, no resolution needed
+image: https://example.com/images/og.png
+
+# Root-relative — resolves against meta.baseURL
+# e.g. baseURL=https://docs.example.com → https://docs.example.com/assets/og.png
+image: /assets/og.png
+
+# Relative to /docs/ — resolves against baseURL + /docs/
+# e.g. baseURL=https://docs.example.com → https://docs.example.com/docs/images/card.png
+image: ./images/card.png
+
+# ❌ Wrong — bare filename does NOT auto-resolve to docs/assets/images/
+# Would resolve to /docs/page-content-1.png, not /docs/assets/images/page-content-1.png
+# image: page-content-1.png
+
+# ✅ Correct path for files inside docs/assets/images/
+image: ./assets/images/page-content-1.png
+```
 
 <Note type="note">
 The `date` field is optional. When omitted, the file's last git modified time takes precedence, falling back to the filesystem mtime.

--- a/packages/flame/docs/getting-started/installation.mdx
+++ b/packages/flame/docs/getting-started/installation.mdx
@@ -58,10 +58,11 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 flame dev        # Start development server with HMR
 flame build      # Build for production
 flame preview    # Preview production build
-flame deploy     # Build + prepare for GitHub Pages
-flame init       # Scaffold a new project
-flame clean      # Clean build artifacts
-flame --help     # Show all commands
+flame deploy              # Build + prepare for GitHub Pages
+flame deploy --docker     # Build + generate Docker files
+flame init              # Scaffold a new project
+flame clean             # Clean build artifacts
+flame --help            # Show all commands
 ```
 
 The CLI auto-detects your runtime and dispatches to the correct server implementation automatically — `flame dev` uses Bun.serve on Bun, Node HTTP on Node.js, and Deno HTTP on Deno. Override detection with the `FLAME_RUNTIME` environment variable:
@@ -77,9 +78,9 @@ Scaffolded projects have these scripts in `package.json`:
 {
   "scripts": {
     "dev": "flame dev",
-    "build": "flame build",
-    "preview": "flame preview",
-    "deploy": "flame deploy"
+    "build": "NODE_ENV=production flame build",
+    "preview": "NODE_ENV=production flame preview",
+    "deploy": "NODE_ENV=production flame deploy"
   }
 }
 ```

--- a/packages/flame/docs/getting-started/runtime-comparison.mdx
+++ b/packages/flame/docs/getting-started/runtime-comparison.mdx
@@ -86,12 +86,12 @@ deno run -A bin/compile-lib.mjs  # Deno
 
 ### Deploy
 
-The `deploy` command prepares `.docu/dist` for GitHub Pages:
+The `deploy` command prepares `.docu/dist/` for deployment:
 
-- **Bun**: spawns `bun run build` as a subprocess, then writes `.nojekyll` + `_headers`.
-- **Node / Deno**: runs the build in-process via `build.impl.runBuildCli()`, then writes `.nojekyll`.
+- **Default** (`flame deploy`): generates `.github/workflows/deploy.yml` for GitHub Pages, writes `.nojekyll` + `_headers`.
+- **Docker** (`flame deploy --docker`): generates `Dockerfile` + `nginx.conf` + `.dockerignore`.
 
-Both generate a `.github/workflows/deploy.yml` if one does not exist. The generated workflow uses the appropriate setup action (`oven-sh/setup-bun` vs `actions/setup-node`).
+The generated GitHub Actions workflow uses the appropriate setup action (`oven-sh/setup-bun` vs `actions/setup-node`).
 
 ### Deno-Specific Notes
 

--- a/packages/flame/docs/getting-started/search/algolia.mdx
+++ b/packages/flame/docs/getting-started/search/algolia.mdx
@@ -3,17 +3,11 @@ title: Algolia
 description: Integrate Algolia DocSearch into your Flame documentation site.
 ---
 
-[Algolia DocSearch](https://docsearch.algolia.com/) provides a fast, relevant search experience for documentation sites. The search on this site **(DocuBook)** runs on Algolia.
-
-Flame's Algolia integration is via a plugin — configure it once in `docu.json` and the plugin injects the search client into the browser bundle.
-
-Algolia is not built into Flame. You add it via a plugin registered in the `plugins` array of `docu.json` — factory options like credentials are passed directly there:
+[Algolia DocSearch](https://docsearch.algolia.com/) provides a fast, relevant search experience for documentation sites. Flame does not include Algolia by default — add it via a plugin registered in the `plugins` array of `docu.json`:
 
 <Note type="info" title="Example configuration — adapt to your plugin">
-  The entry below is an **example** showing how the plugin factory format works.
-  `@docubook/plugin-search-algolia` is a placeholder — replace it with whatever Algolia
-  (or any search) plugin you install. Flame's plugin system only defines the contract;
-  the actual plugin package is provided by you or a third party.
+  The entry below is an **example**. `@docubook/plugin-search-algolia` is a placeholder —
+  replace it with whatever Algolia search plugin you install.
 </Note>
 
 ```json

--- a/packages/flame/docs/getting-started/search/built-in.mdx
+++ b/packages/flame/docs/getting-started/search/built-in.mdx
@@ -7,7 +7,7 @@ DocuBook Flame includes a built-in full-text search that works entirely client-s
 
 ## How It Works
 
-1. **Build-time indexing** — During `bun build`, all MDX files are scanned and a `search-index.json` is generated
+1. **Build-time indexing** — During `flame build`, all MDX files are scanned and a `search-index.json` is generated
 2. **Hierarchy-based records** — Each page produces multiple records: title (lvl1), headings (lvl2–lvl6), and content paragraphs
 3. **Client-side search** — The index is fetched on first modal open and cached in memory
 
@@ -39,29 +39,3 @@ The indexer extracts the following from each MDX file:
 ## Configuration
 
 Search works out of the box with no configuration. The index is automatically regenerated on every build.
-
-To manually regenerate the search index:
-
-<Tabs className="pt-3 pb-1">
-<Tab title="Bun">
-
-```shell:bun
-bun .docu/node/search-indexer.ts
-```
-
-</Tab>
-<Tab title="Node.js">
-
-```shell:bash
-node .docu/lib/search-indexer.js
-```
-
-</Tab>
-<Tab title="Deno">
-
-```shell:bash
-deno run -A .docu/lib/search-indexer.js
-```
-
-</Tab>
-</Tabs>

--- a/packages/flame/template/docs/guide/deployment.mdx
+++ b/packages/flame/template/docs/guide/deployment.mdx
@@ -13,6 +13,19 @@ npm run deploy       # or: bun run deploy / deno task deploy
 
 This builds the site, adds `.nojekyll`, and generates a GitHub Actions workflow on first run.
 
+## Docker (self-hosted / VPS)
+
+```bash
+npm run deploy -- --docker   # or: bun run deploy -- --docker / deno task deploy -- --docker
+```
+
+Generates `Dockerfile` + `nginx.conf` + `.dockerignore` for Docker-based deployments. After generation, build and run:
+
+```bash
+docker build -t my-docs .
+docker run -p 80:80 my-docs
+```
+
 ## Manual
 
 ```bash


### PR DESCRIPTION
## Summary

Sync all documentation with codebase changes from today's releases (v1.6.0 → v1.6.5). 8 files updated, 1 commit.

## Changes

| File | What changed |
|------|-------------|
| `installation.mdx` | CLI reference: added `--docker` flag; build scripts now include `NODE_ENV=production` prefix |
| `deployment.mdx` | Added Docker section (`flame deploy --docker`), Docker row to provider table (trimmed from 28 to 8 lines) |
| `runtime-comparison.mdx` | Deploy section updated with `--docker` option alongside the default GitHub Pages flow |
| `built-in search.mdx` | Removed manual search-indexer commands exposing internal paths; fixed `bun build` → `flame build` |
| `algolia.mdx` | Removed false claim "The search on this site (DocuBook) runs on Algolia" — DocuBook uses built-in search |
| `configuration.mdx` | Added missing `ogImage` field to `meta` table (fallback for per-page OG images) |
| `frontmatter.mdx` | `image` field with explicit absolute / root-relative / `/docs/`-relative path examples; warns bare filenames do **not** auto-resolve to `docs/assets/images/` |
| `template/docs/guide/deployment.mdx` | Added Docker deployment instructions