### PR TITLE
fix(flame): add mtime fallback, cleanup NODE_ENV, fix docs

### DIFF
--- a/.changeset/early-squids-pay.md
+++ b/.changeset/early-squids-pay.md
@@ -1,0 +1,13 @@
+---
+'@docubook/flame': patch
+---
+
+Fix git date fallback and Docker/Vercel deployment dates
+
+- Add `getFilesystemMtime()` fallback in `git.ts` — when git is unavailable
+  (shallow clone, no `.git`), dates fall back to filesystem mtime instead of
+  `undefined`. The chain is now: `frontmatter.date` → `git log` → `mtime`.
+- Remove `.git` from `.dockerignore` — Docker builds now include git history,
+  enabling correct last-modified dates via `git log`.
+- Document `VERCEL_DEEP_CLONE=true` in deployment docs — Vercel's default
+  shallow clone prevents `git log` from resolving per-file dates.

--- a/packages/flame/.docu/__tests__/deploy.test.ts
+++ b/packages/flame/.docu/__tests__/deploy.test.ts
@@ -18,7 +18,7 @@ describe("deploy Docker — generated file content", () => {
     expect(DOCKERIGNORE).toContain(".env");
     expect(DOCKERIGNORE).toContain("*.log");
     expect(DOCKERIGNORE).toContain("node_modules");
-    expect(DOCKERIGNORE).toContain(".git");
+    expect(DOCKERIGNORE).not.toContain(".git");
   });
 
   it("NGINX_CONF includes all security headers at server level", () => {

--- a/packages/flame/.docu/__tests__/mdx.test.ts
+++ b/packages/flame/.docu/__tests__/mdx.test.ts
@@ -40,9 +40,10 @@ vi.mock("@docubook/mdx-content", () => ({
   createMdxComponents: () => ({}),
 }));
 
-vi.mock("../node/utils", () => ({
+vi.mock("../node/git", () => ({
   getGitLastModified: vi.fn(() => null),
   getGitLastModifiedBatch: vi.fn(() => new Map()),
+  getFilesystemMtime: vi.fn(() => "2026-01-01T00:00:00.000Z"),
 }));
 
 // Import after mocks

--- a/packages/flame/.docu/node/deploy.shared.ts
+++ b/packages/flame/.docu/node/deploy.shared.ts
@@ -62,7 +62,6 @@ export const NGINX_CONF = `server {
 `;
 
 export const DOCKERIGNORE = `node_modules
-.git
 *.DS_Store
 .docu/dist
 .docu/lib

--- a/packages/flame/.docu/node/git.ts
+++ b/packages/flame/.docu/node/git.ts
@@ -5,6 +5,7 @@
  */
 
 import { execFile } from "node:child_process";
+import { stat } from "node:fs/promises";
 
 function runGit(args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -30,6 +31,19 @@ export async function getGitLastModified(filePath: string): Promise<string | nul
     const text = await runGit(["log", "-1", "--format=%cI", "--", cleanPath]);
     const date = text.trim();
     return date || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fallback to filesystem mtime when git is unavailable (shallow clone, no .git, etc.).
+ * Returns ISO 8601 date string or null.
+ */
+export async function getFilesystemMtime(filePath: string): Promise<string | null> {
+  try {
+    const stats = await stat(filePath);
+    return stats.mtime.toISOString();
   } catch {
     return null;
   }

--- a/packages/flame/.docu/node/mdx.ts
+++ b/packages/flame/.docu/node/mdx.ts
@@ -9,7 +9,7 @@ import {
   MDXRemote,
 } from "@docubook/core";
 import { createMdxComponents } from "@docubook/mdx-content";
-import { getGitLastModified, getGitLastModifiedBatch } from "./git";
+import { getGitLastModified, getGitLastModifiedBatch, getFilesystemMtime } from "./git";
 
 /**
  * Return the value with `.html` appended, or null if the value should be left
@@ -161,6 +161,7 @@ export async function compileMdx(
     frontmatter.date ||
     gitDates?.get(filePath) ||
     (await getGitLastModified(filePath)) ||
+    (await getFilesystemMtime(filePath)) ||
     undefined;
 
   return {

--- a/packages/flame/bin/cli.js
+++ b/packages/flame/bin/cli.js
@@ -127,8 +127,8 @@ if (command === "init") {
       pkg.scripts = {
         dev: `${flameCmd} dev`,
         build: `NODE_ENV=production ${flameCmd} build`,
-        preview: `NODE_ENV=production ${flameCmd} preview`,
-        deploy: `NODE_ENV=production ${flameCmd} deploy`,
+        preview: `${flameCmd} preview`,
+        deploy: `${flameCmd} deploy`,
       };
 
       // Generate deno.json with nodeModulesDir for npm compat.

--- a/packages/flame/docs/getting-started/deployment.mdx
+++ b/packages/flame/docs/getting-started/deployment.mdx
@@ -78,6 +78,13 @@ When `true`, Vercel strips `.html` from all URLs and responds with a `308` redir
 
 Source: [Vercel — cleanUrls](https://vercel.com/docs/project-configuration/vercel-json#cleanurls)
 
+<Note type="info" title="Last updated dates on Vercel">
+  Vercel uses a shallow git clone (`--depth=1`) by default, which prevents Flame from
+  reading the last modified date for each page via `git log`. Set the environment variable
+  `VERCEL_DEEP_CLONE=true` in your Vercel project dashboard (Settings → Environment
+  Variables) to enable full git history and correct dates.
+</Note>
+
 ### Netlify
 
 ```toml:netlify.toml

--- a/packages/flame/docs/getting-started/deployment.mdx
+++ b/packages/flame/docs/getting-started/deployment.mdx
@@ -80,9 +80,12 @@ Source: [Vercel — cleanUrls](https://vercel.com/docs/project-configuration/ver
 
 <Note type="info" title="Last updated dates on Vercel">
   Vercel uses a shallow git clone (`--depth=1`) by default, which prevents Flame from
-  reading the last modified date for each page via `git log`. Set the environment variable
-  `VERCEL_DEEP_CLONE=true` in your Vercel project dashboard (Settings → Environment
-  Variables) to enable full git history and correct dates.
+  reading the last modified date for each page via `git log`. Add the following environment
+  variable in your Vercel project dashboard (Settings → Environment Variables):
+
+  | Key | Value |
+  | --- | ----- |
+  | `VERCEL_DEEP_CLONE` | `true` |
 </Note>
 
 ### Netlify

--- a/packages/flame/docs/getting-started/frontmatter.mdx
+++ b/packages/flame/docs/getting-started/frontmatter.mdx
@@ -23,7 +23,7 @@ Below is a table of available frontmatter fields for documentation pages:
 | title       | string       | Yes      | The page title, displayed in the header and metadata. |
 | description | string       | Yes      | A short description of the page, used for SEO and previews. |
 | image       | string (URL) | No       | Per-page OG image (`og:image`) for social sharing. Falls back to `meta.ogImage` in `docu.json`. See examples below for accepted path formats. |
-| date        | string       | No       | Publication date in `YYYY-MM-DD` format (e.g. `2026-06-10`). If omitted, the file's last modified time is used automatically. |
+| date        | string       | No       | Publication date in `YYYY-MM-DD` format (e.g. `2026-06-10`). If omitted, resolves from: `git log` → filesystem `mtime` → hidden. |
 
 ### Image path examples
 

--- a/packages/flame/docs/getting-started/installation.mdx
+++ b/packages/flame/docs/getting-started/installation.mdx
@@ -79,8 +79,8 @@ Scaffolded projects have these scripts in `package.json`:
   "scripts": {
     "dev": "flame dev",
     "build": "NODE_ENV=production flame build",
-    "preview": "NODE_ENV=production flame preview",
-    "deploy": "NODE_ENV=production flame deploy"
+    "preview": "flame preview",
+    "deploy": "flame deploy"
   }
 }
 ```

--- a/packages/flame/template/docs/guide/deployment.mdx
+++ b/packages/flame/template/docs/guide/deployment.mdx
@@ -16,10 +16,10 @@ This builds the site, adds `.nojekyll`, and generates a GitHub Actions workflow 
 ## Docker (self-hosted / VPS)
 
 ```bash
-npm run deploy -- --docker   # or: bun run deploy -- --docker / deno task deploy -- --docker
+flame deploy --docker
 ```
 
-Generates `Dockerfile` + `nginx.conf` + `.dockerignore` for Docker-based deployments. After generation, build and run:
+Generates `Dockerfile` + `nginx.conf` + `.dockerignore`. Build and run:
 
 ```bash
 docker build -t my-docs .

--- a/packages/flame/template/package.json
+++ b/packages/flame/template/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "dev": "flame dev",
     "build": "NODE_ENV=production flame build",
-    "preview": "NODE_ENV=production flame preview",
-    "deploy": "NODE_ENV=production flame deploy"
+    "preview": "flame preview",
+    "deploy": "flame deploy"
   },
   "dependencies": {
     "@docubook/flame": "latest"


### PR DESCRIPTION
## Summary

Fix git date resolution on Vercel (shallow clone) and Docker (no .git), cleanup redundant NODE_ENV, sync docs with codebase.

---

### 1. stat.mtime fallback (git.ts + mdx.ts)

**Problem:** Vercel shallow clone and Docker builds without .git cause git log to fail. Date chain stopped at undefined.

**Fix:** Add getFilesystemMtime() using fs.stat.mtime as final fallback. Chain: frontmatter.date &rarr; git log batch &rarr; git log single &rarr; stat.mtime &rarr; undefined

| File | Change |
|------|--------|
| git.ts | Add getFilesystemMtime() export |
| mdx.ts | Call getFilesystemMtime after git lookup |

### 2. Remove .git from Dockerignore (deploy.shared.ts)

**Problem:** .dockerignore excluded .git, Docker builds had no git history.

**Fix:** Remove .git from DOCKERIGNORE.

| File | Change |
|------|--------|
| deploy.shared.ts | Remove .git from DOCKERIGNORE |
| deploy.test.ts | Update assertion to not.toContain(.git) |

### 3. VERCEL_DEEP_CLONE documentation (deployment.mdx)

**Problem:** Vercel users don't know they need VERCEL_DEEP_CLONE=true.

**Fix:** Add note with key/value table in Vercel section.

| Key | Value |
| --- | ----- |
| VERCEL_DEEP_CLONE | true |

### 4. Cleanup redundant NODE_ENV (template + cli.js + docs)

**Problem:** NODE_ENV=production was added to preview and deploy, but only build needs SSR JSX production mode. preview uses jsxDEV() and deploy.shared.ts already sets NODE_ENV internally.

**Fix:** Keep NODE_ENV=production only on build.

| File | Before | After |
|------|--------|-------|
| template/package.json | preview/deploy with NODE_ENV | plain flame preview/deploy |
| bin/cli.js (Deno init) | Same | Same |
| installation.mdx | Scripts JSON | Synced |

### 5. Fix deploy command docs (template/deployment.mdx)

**Problem:** npm run deploy -- --docker has confusing syntax.

**Fix:** Use flame deploy --docker directly.

### 6. Explicit date chain in frontmatter.mdx

**Before:** If omitted, the file's last modified time is used automatically

**After:** If omitted, resolves from: git log &rarr; filesystem mtime &rarr; hidden

### Files changed (11 files, +49/-12)

- .changeset/early-squids-pay.md
- packages/flame/.docu/__tests__/deploy.test.ts
- packages/flame/.docu/node/deploy.shared.ts
- packages/flame/.docu/node/git.ts
- packages/flame/.docu/node/mdx.ts
- packages/flame/bin/cli.js
- packages/flame/docs/getting-started/deployment.mdx
- packages/flame/docs/getting-started/frontmatter.mdx
- packages/flame/docs/getting-started/installation.mdx
- packages/flame/template/docs/guide/deployment.mdx
- packages/flame/template/package.json

### Verification
- Tests: 437 passed