### PR TITLE
docs(flame): fix npm install command

### DIFF
--- a/packages/flame/docs/getting-started/installation.mdx
+++ b/packages/flame/docs/getting-started/installation.mdx
@@ -22,7 +22,7 @@ bun run dev
 
 ```shell:bash
 mkdir my-docs && cd my-docs
-npm add @docubook/flame
+npm install @docubook/flame
 npx flame init
 npm run dev
 ```
@@ -100,7 +100,7 @@ bun add -g @docubook/flame
 <Tab title="Node.js">
 
 ```shell:bash
-npm add -g @docubook/flame
+npm install -g @docubook/flame
 ```
 
 </Tab>


### PR DESCRIPTION
Fix Node.js install command from `npm add` to `npm install` — `npm add` is not a standard npm command.