### PR TITLE
feat(flame): add docker builder base image and CI workflow

### DIFF
--- a/.changeset/slimy-dingos-fly.md
+++ b/.changeset/slimy-dingos-fly.md
@@ -1,0 +1,11 @@
+---
+'@docubook/flame': minor
+---
+
+Add Docker builder base image (`ghcr.io/docubook/flame-builder`) for zero-config Docker deployment
+
+- New `packages/flame/docker/Dockerfile.builder` — base image with `@docubook/flame` pre-installed globally
+- New `.github/workflows/docker-builder.yml` — auto-publish base image to GHCR on release
+- `flame deploy --docker` now generates Dockerfile using `flame-builder:MAJOR` (e.g. `:1`) instead of building from `oven/bun`
+- `flame deploy --docker` also generates `.github/workflows/deploy-docker.yml` — CI auto-builds & pushes user's site image on `git push`
+- Major version tag (`:1`) ensures patch and minor updates are automatic on redeploy

--- a/.changeset/slimy-dingos-fly.md
+++ b/.changeset/slimy-dingos-fly.md
@@ -7,5 +7,6 @@ Add Docker builder base image (`ghcr.io/docubook/flame-builder`) for zero-config
 - New `packages/flame/docker/Dockerfile.builder` — base image with `@docubook/flame` pre-installed globally
 - New `.github/workflows/docker-builder.yml` — auto-publish base image to GHCR on release
 - `flame deploy --docker` now generates Dockerfile using `flame-builder:MAJOR` (e.g. `:1`) instead of building from `oven/bun`
-- `flame deploy --docker` also generates `.github/workflows/deploy-docker.yml` — CI auto-builds & pushes user's site image on `git push`
+- `flame deploy --docker` generates Dockerfile using `flame-builder:MAJOR` — simpler, no local Bun/npm needed
+- `flame deploy --docker --ci` also generates `.github/workflows/deploy-docker.yml` — CI auto-builds & pushes user's site image to GHCR on `git push`
 - Major version tag (`:1`) ensures patch and minor updates are automatic on redeploy

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -1,0 +1,51 @@
+name: Publish Flame Builder Docker Image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Flame version (e.g. 1.6.6) — empty = from packages/flame/package.json"
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Derive version
+        id: version
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION=$(jq -r '.version' packages/flame/package.json)
+          fi
+          MAJOR="$(echo "$VERSION" | cut -d. -f1)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: packages/flame/docker/Dockerfile.builder
+          build-args: |
+            FLAME_VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            ghcr.io/docubook/flame-builder:${{ steps.version.outputs.version }}
+            ghcr.io/docubook/flame-builder:${{ steps.version.outputs.major }}
+            ghcr.io/docubook/flame-builder:latest
+          push: true

--- a/packages/flame/.docu/__tests__/deploy.test.ts
+++ b/packages/flame/.docu/__tests__/deploy.test.ts
@@ -6,10 +6,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 describe("deploy Docker — generated file content", () => {
-  it("Dockerfile uses oven/bun:1-debian for Bun path", () => {
-    expect(DOCKERFILE_BUN).toContain("oven/bun:1-debian");
+  it("Dockerfile uses ghcr.io/docubook/flame-builder:MAJOR tag", () => {
+    expect(DOCKERFILE_BUN).toMatch(/ghcr\.io\/docubook\/flame-builder:[0-9]+ AS builder/);
     expect(DOCKERFILE_BUN).toContain("nginx:alpine");
-    expect(DOCKERFILE_BUN).toContain("bun.lock");
+    expect(DOCKERFILE_BUN).toContain("flame build");
   });
 
   it(".dockerignore excludes build artifacts and secrets", () => {

--- a/packages/flame/.docu/__tests__/deploy.test.ts
+++ b/packages/flame/.docu/__tests__/deploy.test.ts
@@ -6,10 +6,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 describe("deploy Docker — generated file content", () => {
-  it("Dockerfile uses ghcr.io/docubook/flame-builder:MAJOR tag", () => {
+  it("Dockerfile uses ghcr.io/docubook/flame-builder:MAJOR tag with ENV NODE_ENV", () => {
     expect(DOCKERFILE_BUN).toMatch(/ghcr\.io\/docubook\/flame-builder:[0-9]+ AS builder/);
     expect(DOCKERFILE_BUN).toContain("nginx:alpine");
-    expect(DOCKERFILE_BUN).toContain("flame build");
+    expect(DOCKERFILE_BUN).toContain("ENV NODE_ENV=production");
+    expect(DOCKERFILE_BUN).toContain("RUN flame build");
   });
 
   it(".dockerignore excludes build artifacts and secrets", () => {

--- a/packages/flame/.docu/node/deploy.shared.ts
+++ b/packages/flame/.docu/node/deploy.shared.ts
@@ -172,6 +172,7 @@ async function writeDockerFiles() {
     await writeFile(
       join(dockerDir, "Dockerfile"),
       `FROM ghcr.io/docubook/flame-builder:${FLAME_MAJOR} AS builder
+ENV NODE_ENV=production
 WORKDIR /app
 COPY . .
 RUN flame build

--- a/packages/flame/.docu/node/deploy.shared.ts
+++ b/packages/flame/.docu/node/deploy.shared.ts
@@ -9,9 +9,13 @@
  */
 
 import { writeFile, mkdir } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-import { DIST_DIR, PROJECT_ROOT } from "./paths";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { DIST_DIR, PROJECT_ROOT, FRAMEWORK_ROOT } from "./paths";
+
+const FLAME_MAJOR = JSON.parse(
+  readFileSync(resolve(FRAMEWORK_ROOT, "package.json"), "utf-8")
+).version.split(".")[0];
 
 const WORKFLOW_DIR = join(PROJECT_ROOT, ".github/workflows");
 const WORKFLOW_FILE = join(WORKFLOW_DIR, "deploy.yml");
@@ -162,18 +166,14 @@ async function runBuild() {
 
 async function writeDockerFiles() {
   const dockerDir = PROJECT_ROOT;
-  const pm = detectPkgManager(dockerDir);
 
   if (!existsSync(join(dockerDir, "Dockerfile"))) {
     await writeFile(
       join(dockerDir, "Dockerfile"),
-      `FROM ${pm.baseImage} AS builder
-ENV NODE_ENV=production
+      `FROM ghcr.io/docubook/flame-builder:${FLAME_MAJOR} AS builder
 WORKDIR /app
-COPY package.json ${pm.lockFile} ./
-RUN ${pm.installCmd}
 COPY . .
-RUN ${pm.runCmd} run build
+RUN flame build
 
 FROM nginx:alpine
 COPY --from=builder /app/.docu/dist /usr/share/nginx/html
@@ -279,11 +279,59 @@ function generateWorkflowYml(): string {
   ].join("\n");
 }
 
+function generateDockerWorkflowYml(): string {
+  const imageName = "ghcr.io/${{ github.repository }}";
+  return [
+    `name: Build & Push Docker Image`,
+    "",
+    "on:",
+    "  push:",
+    "    branches: [main]",
+    "  workflow_dispatch:",
+    "",
+    "permissions:",
+    "  contents: read",
+    "  packages: write",
+    "",
+    "jobs:",
+    "  build:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          fetch-depth: 0",
+    "",
+    "      - name: Log in to GHCR",
+    "        uses: docker/login-action@v3",
+    "        with:",
+    "          registry: ghcr.io",
+    "          username: ${{ github.actor }}",
+    "          password: ${{ secrets.GITHUB_TOKEN }}",
+    "",
+    "      - name: Build & push",
+    "        uses: docker/build-push-action@v5",
+    "        with:",
+    "          context: .",
+    `          tags: ${imageName}:latest`,
+    "          push: true",
+  ].join("\n");
+}
+
 async function writeGhaWorkflow() {
   if (!existsSync(WORKFLOW_FILE)) {
     await mkdir(WORKFLOW_DIR, { recursive: true });
     await writeFile(WORKFLOW_FILE, generateWorkflowYml());
     log.created("📄 Created .github/workflows/deploy.yml");
+  }
+}
+
+const DOCKER_WORKFLOW_FILE = join(WORKFLOW_DIR, "deploy-docker.yml");
+
+async function writeDockerWorkflow() {
+  if (!existsSync(DOCKER_WORKFLOW_FILE)) {
+    await mkdir(WORKFLOW_DIR, { recursive: true });
+    await writeFile(DOCKER_WORKFLOW_FILE, generateDockerWorkflowYml());
+    log.created("📄 Created .github/workflows/deploy-docker.yml");
   }
 }
 
@@ -297,6 +345,7 @@ export async function runDeploy(): Promise<void> {
 
   if (isDocker) {
     await writeDockerFiles();
+    await writeDockerWorkflow();
   } else {
     await writeGhaWorkflow();
   }
@@ -304,7 +353,8 @@ export async function runDeploy(): Promise<void> {
   log.ok();
   log.out("   Output: .docu/dist/");
   if (isDocker) {
-    log.out("   Run: docker build -t my-docs . && docker run -p 80:80 my-docs");
+    log.out("   Push to GitHub — CI will build & push Docker image to GHCR");
+    log.out("   Then pull latest image on your hosting platform (Coolify, etc.)");
   } else {
     log.out("   Push to GitHub and enable Pages (Settings → Pages → Source: GitHub Actions)");
   }

--- a/packages/flame/.docu/node/deploy.shared.ts
+++ b/packages/flame/.docu/node/deploy.shared.ts
@@ -143,6 +143,7 @@ export const HEADERS_FILE = `/*
 
 const isDocker = !!process.env.FLAME_DEPLOY_DOCKER;
 const isSilent = !!process.env.FLAME_DEPLOY_SILENT;
+const isCi = !!process.env.FLAME_DEPLOY_CI;
 
 /** Logger that no-ops all non-error output in silent mode. */
 const log = isSilent
@@ -345,7 +346,7 @@ export async function runDeploy(): Promise<void> {
 
   if (isDocker) {
     await writeDockerFiles();
-    await writeDockerWorkflow();
+    if (isCi) await writeDockerWorkflow();
   } else {
     await writeGhaWorkflow();
   }
@@ -353,8 +354,13 @@ export async function runDeploy(): Promise<void> {
   log.ok();
   log.out("   Output: .docu/dist/");
   if (isDocker) {
-    log.out("   Push to GitHub — CI will build & push Docker image to GHCR");
-    log.out("   Then pull latest image on your hosting platform (Coolify, etc.)");
+    log.out("   Build locally: docker build -t my-docs . && docker run -p 80:80 my-docs");
+    if (isCi) {
+      log.out("   Push to GitHub — CI will build & push Docker image to GHCR");
+      log.out("   Then pull latest image on your hosting platform (Coolify, etc.)");
+    } else {
+      log.out("   For Coolify: connect repo, set build pack to Dockerfile");
+    }
   } else {
     log.out("   Push to GitHub and enable Pages (Settings → Pages → Source: GitHub Actions)");
   }

--- a/packages/flame/.docu/node/deploy.ts
+++ b/packages/flame/.docu/node/deploy.ts
@@ -25,6 +25,7 @@ const DOCKER_WORKFLOW_FILE = join(WORKFLOW_DIR, "deploy-docker.yml");
 
 const isDocker = !!process.env.FLAME_DEPLOY_DOCKER;
 const isSilent = !!process.env.FLAME_DEPLOY_SILENT;
+const isCi = !!process.env.FLAME_DEPLOY_CI;
 
 /** Logger that no-ops all non-error output in silent mode. */
 const log = isSilent
@@ -143,7 +144,7 @@ async function deploy() {
 
   if (isDocker) {
     await writeDockerFiles();
-    await writeDockerWorkflow();
+    if (isCi) await writeDockerWorkflow();
   } else {
     await writeGhaWorkflow();
   }
@@ -151,8 +152,13 @@ async function deploy() {
   log.ok();
   log.out("   Output: .docu/dist/");
   if (isDocker) {
-    log.out("   Push to GitHub — CI will build & push Docker image to GHCR");
-    log.out("   Then pull latest image on your hosting platform (Coolify, etc.)");
+    log.out("   Build locally: docker build -t my-docs . && docker run -p 80:80 my-docs");
+    if (isCi) {
+      log.out("   Push to GitHub — CI will build & push Docker image to GHCR");
+      log.out("   Then pull latest image on your hosting platform (Coolify, etc.)");
+    } else {
+      log.out("   For Coolify: connect repo, set build pack to Dockerfile");
+    }
   } else {
     log.out("   Push to GitHub and enable Pages (Settings → Pages → Source: GitHub Actions)");
   }

--- a/packages/flame/.docu/node/deploy.ts
+++ b/packages/flame/.docu/node/deploy.ts
@@ -8,15 +8,20 @@
  */
 
 import { mkdir } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-import { DIST_DIR, PROJECT_ROOT } from "./paths";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { DIST_DIR, PROJECT_ROOT, FRAMEWORK_ROOT } from "./paths";
 import { HEADERS_FILE, NGINX_CONF, DOCKERIGNORE } from "./deploy.shared";
+
+const FLAME_PKG = JSON.parse(readFileSync(resolve(FRAMEWORK_ROOT, "package.json"), "utf-8"));
+const FLAME_VERSION = FLAME_PKG.version;
+const FLAME_MAJOR = FLAME_VERSION.split(".")[0];
 
 export { HEADERS_FILE, NGINX_CONF, DOCKERIGNORE };
 
 const WORKFLOW_DIR = join(PROJECT_ROOT, ".github/workflows");
 const WORKFLOW_FILE = join(WORKFLOW_DIR, "deploy.yml");
+const DOCKER_WORKFLOW_FILE = join(WORKFLOW_DIR, "deploy-docker.yml");
 
 const isDocker = !!process.env.FLAME_DEPLOY_DOCKER;
 const isSilent = !!process.env.FLAME_DEPLOY_SILENT;
@@ -43,13 +48,10 @@ async function runBuild() {
   }
 }
 
-export const DOCKERFILE_BUN = `FROM oven/bun:1-debian AS builder
-ENV NODE_ENV=production
+export const DOCKERFILE_BUN = `FROM ghcr.io/docubook/flame-builder:${FLAME_MAJOR} AS builder
 WORKDIR /app
-COPY package.json bun.lock ./
-RUN bun install --frozen-lockfile
 COPY . .
-RUN bun run build
+RUN flame build
 
 FROM nginx:alpine
 COPY --from=builder /app/.docu/dist /usr/share/nginx/html
@@ -85,6 +87,52 @@ async function writeGhaWorkflow() {
   }
 }
 
+function generateDockerWorkflowYml(): string {
+  const imageName = "ghcr.io/${{ github.repository }}";
+  return [
+    `name: Build & Push Docker Image`,
+    "",
+    "on:",
+    "  push:",
+    "    branches: [main]",
+    "  workflow_dispatch:",
+    "",
+    "permissions:",
+    "  contents: read",
+    "  packages: write",
+    "",
+    "jobs:",
+    "  build:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          fetch-depth: 0",
+    "",
+    "      - name: Log in to GHCR",
+    "        uses: docker/login-action@v3",
+    "        with:",
+    "          registry: ghcr.io",
+    "          username: ${{ github.actor }}",
+    "          password: ${{ secrets.GITHUB_TOKEN }}",
+    "",
+    "      - name: Build & push",
+    "        uses: docker/build-push-action@v5",
+    "        with:",
+    "          context: .",
+    `          tags: ${imageName}:latest`,
+    "          push: true",
+  ].join("\n");
+}
+
+async function writeDockerWorkflow() {
+  if (!existsSync(DOCKER_WORKFLOW_FILE)) {
+    await mkdir(WORKFLOW_DIR, { recursive: true });
+    await Bun.write(DOCKER_WORKFLOW_FILE, generateDockerWorkflowYml());
+    log.created("📄 Created .github/workflows/deploy-docker.yml");
+  }
+}
+
 async function deploy() {
   log.info("📦 Building for production...\n");
   await runBuild();
@@ -95,6 +143,7 @@ async function deploy() {
 
   if (isDocker) {
     await writeDockerFiles();
+    await writeDockerWorkflow();
   } else {
     await writeGhaWorkflow();
   }
@@ -102,7 +151,8 @@ async function deploy() {
   log.ok();
   log.out("   Output: .docu/dist/");
   if (isDocker) {
-    log.out("   Run: docker build -t my-docs . && docker run -p 80:80 my-docs");
+    log.out("   Push to GitHub — CI will build & push Docker image to GHCR");
+    log.out("   Then pull latest image on your hosting platform (Coolify, etc.)");
   } else {
     log.out("   Push to GitHub and enable Pages (Settings → Pages → Source: GitHub Actions)");
   }

--- a/packages/flame/.docu/node/deploy.ts
+++ b/packages/flame/.docu/node/deploy.ts
@@ -50,6 +50,7 @@ async function runBuild() {
 }
 
 export const DOCKERFILE_BUN = `FROM ghcr.io/docubook/flame-builder:${FLAME_MAJOR} AS builder
+ENV NODE_ENV=production
 WORKDIR /app
 COPY . .
 RUN flame build

--- a/packages/flame/bin/cli.js
+++ b/packages/flame/bin/cli.js
@@ -58,8 +58,10 @@ if (themeIndex !== -1 && themeIndex + 1 < process.argv.length) {
 }
 const hasDocker = process.argv.includes("--docker");
 const hasSilent = process.argv.includes("--silent");
+const hasCi = process.argv.includes("--ci");
 if (hasDocker) process.env.FLAME_DEPLOY_DOCKER = "1";
 if (hasSilent) process.env.FLAME_DEPLOY_SILENT = "1";
+if (hasCi) process.env.FLAME_DEPLOY_CI = "1";
 
 // Production mode for build/preview/deploy — ensures minified client bundle
 // on all platforms (Coolify, Vercel, etc.) without requiring the user to
@@ -88,7 +90,8 @@ if (!command || command === "--help" || command === "-h") {
   Options:
     --help        Show this help message
     --theme <name>  Override theme preset (e.g. freshlime, coffee). Works with dev, build, preview.
-    --docker      Generate Docker deployment files (Dockerfile + nginx.conf). Works with deploy.
+    --docker      Generate Docker deployment files (Dockerfile + nginx.conf + .dockerignore). Works with deploy.
+    --ci          Generate CI workflow (.github/workflows/deploy-docker.yml) for auto build & push to GHCR. Use with --docker.
     --silent      Suppress non-essential output. Works with deploy.
 `);
   process.exit(0);

--- a/packages/flame/docker/Dockerfile.builder
+++ b/packages/flame/docker/Dockerfile.builder
@@ -7,6 +7,9 @@ LABEL org.opencontainers.image.licenses="MIT"
 
 ARG FLAME_VERSION=latest
 
+# Set NODE_ENV so Bun picks the production JSX transform
+ENV NODE_ENV=production
+
 # Install flame CLI globally (available as `flame` from any WORKDIR)
 RUN bun install -g @docubook/flame@${FLAME_VERSION} && \
     flame --help > /dev/null 2>&1

--- a/packages/flame/docker/Dockerfile.builder
+++ b/packages/flame/docker/Dockerfile.builder
@@ -1,0 +1,14 @@
+FROM oven/bun:1-debian
+
+LABEL org.opencontainers.image.title="DocuBook Flame Builder"
+LABEL org.opencontainers.image.description="Pre-installed @docubook/flame CLI — user supplies content via COPY or volume"
+LABEL org.opencontainers.image.source="https://github.com/DocuBook/docubook"
+LABEL org.opencontainers.image.licenses="MIT"
+
+ARG FLAME_VERSION=latest
+
+# Install flame CLI globally (available as `flame` from any WORKDIR)
+RUN bun install -g @docubook/flame@${FLAME_VERSION} && \
+    flame --help > /dev/null 2>&1
+
+WORKDIR /app

--- a/packages/flame/docs/getting-started/deployment.mdx
+++ b/packages/flame/docs/getting-started/deployment.mdx
@@ -30,8 +30,8 @@ Whether the `.html` suffix stays visible in the browser address bar depends on y
 | Azure Static Web Apps | Yes        | Native GitHub       | Azure infra       | `staticwebapp.config.json`     |
 | Render                | Yes        | Native GitHub       | nginx             | Dashboard rewrite rule         |
 | Heroku                | Yes        | Native GitHub       | nginx             | Static buildpack + `static.json` |
-| **Docker**            | **Yes**    | **Any CI/CD**       | **nginx**         | **`flame deploy --docker`**    |
-| GitHub Pages          | No         | Native GitHub       | Apache            | Not supported                  |
+| **Docker**            | **Yes**    | **GitHub Action**       | **nginx**         | **`flame deploy --docker`** or `--docker --ci` |
+| GitHub Pages          | No         | Native GitHub       | Apache            | `flame deploy` (no flag)                  |
 | AWS S3 + CloudFront   | Limited    | GitHub Action       | nginx (CloudFront)| CloudFront Function required   |
 
 Column notes:
@@ -178,16 +178,72 @@ Source: [GitHub Pages documentation](https://docs.github.com/en/pages)
 
 ### Docker
 
+Flame supports Docker deployment for any platform that runs Docker images — Coolify, Fly.io, Railway, VPS, or container hosting.
+
 ```shell
 flame deploy --docker
 ```
 
-Generates `Dockerfile` + `nginx.conf` + `.dockerignore`. Build and run:
+Generates:
+- `Dockerfile` — multi-stage build using `ghcr.io/docubook/flame-builder:MAJOR`
+- `nginx.conf` — security headers, cache tiers, `try_files $uri $uri.html`
+- `.dockerignore` — optimized for build speed
+
+The generated Dockerfile uses a **major version tag** (`:1`, `:2`, etc.). This means:
+- **Patch and minor updates** (1.6.6 → 1.7.0) are automatic — rebuild pulls the latest 1.x base image
+- **Major upgrades** (1.x → 2.x) require explicitly editing the tag in `Dockerfile`
+
+#### Build locally
 
 ```shell
+cd my-project/
+flame deploy --docker
+
 docker build -t my-docs .
 docker run -p 80:80 my-docs
 ```
+
+#### Auto-build on push (with CI)
+
+```shell
+flame deploy --docker --ci
+```
+
+Also generates `.github/workflows/deploy-docker.yml` — a CI workflow that automatically builds and pushes the Docker image to GitHub Container Registry on every `git push`:
+
+```yaml
+# .github/workflows/deploy-docker.yml
+name: Build & Push Docker Image
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+      - uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+```
+
+The image is pushed to `ghcr.io/your-org/your-repo:latest`. Your hosting platform (Coolify, Fly.io, etc.) can then pull the latest image.
+
+#### Platform guide
+
+| Platform | Build pack | Deploy method |
+|----------|-----------|--------------|
+| Coolify | Dockerfile | Connect repo, set build pack to Dockerfile. Or pull pre-built image from GHCR. |
+| Fly.io | Dockerfile | `fly deploy` — auto-detects Dockerfile in repo. |
+| Railway | Dockerfile | Auto-detects Dockerfile, deploys on push. |
+| VPS | docker-compose / docker run | `docker pull` + `docker run` |
+| Any Docker host | Dockerfile | `docker build` + `docker run`
 
 ### AWS S3 + CloudFront
 


### PR DESCRIPTION
Add ghcr.io/docubook/flame-builder base image with flame CLI pre-installed.
User content injected via COPY in their Dockerfile, built via RUN flame build.

## Changes

- `packages/flame/docker/Dockerfile.builder` — base image: `oven/bun:1-debian` + `bun install -g @docubook/flame`
- `.github/workflows/docker-builder.yml` — CI to publish base image to GHCR on release
- `flame deploy --docker` — generates Dockerfile using `flame-builder:MAJOR` tag (e.g. `:1`)
- `flame deploy --docker --ci` — same + generate `deploy-docker.yml` CI workflow for GHCR
- Major version tag (`:1`) ensures patch/minor updates are automatic on redeploy
- Updated `deployment.mdx` docs with Docker platform guide and --ci flag

## Usage

### Coolify / Docker build pack (no CI needed)
```
flame deploy --docker
# → Dockerfile + nginx.conf + .dockerignore
# → Connect repo to coolify, set build pack Dockerfile
```

### GitHub Actions CI (optional)
```
flame deploy --docker --ci
# → + .github/workflows/deploy-docker.yml
# → CI builds & pushes to GHCR on git push
```

## Test
21 tests pass, 0 fail.