### PR TITLE
fix: override dompurify to ^3.4.12 (GHSA-c2j3-45gr-mqc4)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   read-yaml-file: ^2.1.0
   undici: ^7.28.0
   fast-uri: ^4.1.1
+  dompurify: ^3.4.12
 
 importers:
   .:
@@ -4025,10 +4026,10 @@ packages:
         integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==,
       }
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     resolution:
       {
-        integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==,
+        integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==,
       }
 
   dotenv@8.6.0:
@@ -10258,7 +10259,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       "@types/trusted-types": 2.0.7
 
@@ -11621,7 +11622,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       es-toolkit: 1.49.0
       katex: 0.16.47
       khroma: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ overrides:
   "read-yaml-file": "^2.1.0"
   undici: "^7.28.0"
   fast-uri: "^4.1.1"
+  dompurify: "^3.4.12"
 allowBuilds:
   "@parcel/watcher": true
   bun: true


### PR DESCRIPTION
Dependabot alert #26 — DOMPurify `CUSTOM_ELEMENT_HANDLING` bypasses `afterSanitizeElements` for allowed custom elements (low severity).

dompurify@3.4.11 (via mermaid → @docubook/mdx-content) vulnerable to CUSTOM_ELEMENT_HANDLING bypass.

Override: `dompurify: "^3.4.12"` in pnpm-workspace.yaml. Resolved to 3.4.12 in lockfile.