### PR TITLE
fix: use SHA256 for Tailwind cache key in hydrate

### DIFF
--- a/.changeset/smart-pandas-refactor.md
+++ b/.changeset/smart-pandas-refactor.md
@@ -2,7 +2,6 @@
 '@docubook/flame': patch
 ---
 
-Use SHA256 instead of MD5 for Tailwind cache key in hydrate; pass decoded pathname to isPathSafe
+Use SHA256 instead of MD5 for Tailwind cache key in hydrate
 
 - `hydrate.ts` / `hydrate.node.ts`: MD5 → SHA256 for content-addressable cache key (consistency with build path)
-- `server-routes.ts`: pass `decoded` instead of `pathname` to `isPathSafe()` (validate what you use)

--- a/.changeset/smart-pandas-refactor.md
+++ b/.changeset/smart-pandas-refactor.md
@@ -1,0 +1,8 @@
+---
+'@docubook/flame': patch
+---
+
+Use SHA256 instead of MD5 for Tailwind cache key in hydrate; pass decoded pathname to isPathSafe
+
+- `hydrate.ts` / `hydrate.node.ts`: MD5 → SHA256 for content-addressable cache key (consistency with build path)
+- `server-routes.ts`: pass `decoded` instead of `pathname` to `isPathSafe()` (validate what you use)

--- a/packages/flame/.docu/node/hydrate.node.ts
+++ b/packages/flame/.docu/node/hydrate.node.ts
@@ -71,7 +71,7 @@ function tailwindCacheKey(): string {
   } catch {
     // theme config unavailable — proceed without it
   }
-  return createHash("md5")
+  return createHash("sha256")
     .update(globalsContent + themeSuffix)
     .digest("hex")
     .slice(0, 16);

--- a/packages/flame/.docu/node/hydrate.ts
+++ b/packages/flame/.docu/node/hydrate.ts
@@ -68,7 +68,7 @@ function twCacheKey(): string {
   } catch {
     // theme config unavailable — proceed without
   }
-  return createHash("md5")
+  return createHash("sha256")
     .update(globals + themeSuffix)
     .digest("hex")
     .slice(0, 16);

--- a/packages/flame/.docu/node/server-routes.ts
+++ b/packages/flame/.docu/node/server-routes.ts
@@ -246,7 +246,7 @@ export function serveStatic(pathname: string): Response | null {
   } catch {
     return null;
   }
-  if (!isPathSafe(decoded, DIST_DIR)) return null;
+  if (!isPathSafe(pathname, DIST_DIR)) return null;
   const assetPath = resolve(DIST_DIR, decoded.slice(1));
   try {
     const s = statSync(assetPath);

--- a/packages/flame/.docu/node/server-routes.ts
+++ b/packages/flame/.docu/node/server-routes.ts
@@ -246,7 +246,7 @@ export function serveStatic(pathname: string): Response | null {
   } catch {
     return null;
   }
-  if (!isPathSafe(pathname, DIST_DIR)) return null;
+  if (!isPathSafe(decoded, DIST_DIR)) return null;
   const assetPath = resolve(DIST_DIR, decoded.slice(1));
   try {
     const s = statSync(assetPath);


### PR DESCRIPTION
### Changes

**hydrate.ts / hydrate.node.ts** — Replace MD5 with SHA256 for Tailwind CSS cache key. Both produce 16-char hex, SHA256 is consistent with `build.ts` which already uses SHA256. No security impact (cache key only), purely consistency.

### Files changed
2 files (excl. changeset): hydrate.ts, hydrate.node.ts

### Test
```
turbo: 22/22 tasks successful
security: 170 pass
deploy: 21 pass
```