### PR TITLE
feat(mdx-content): improve mermaid viewing UX with contextual fullscreen controls

### DIFF
--- a/.changeset/mighty-clouds-dance.md
+++ b/.changeset/mighty-clouds-dance.md
@@ -1,0 +1,14 @@
+---
+'@docubook/mdx-content': patch
+'@docubook/flame': patch
+---
+
+feat(mdx-content): improve mermaid viewing UX with contextual fullscreen controls
+
+- Remove `panZoom` prop — fullscreen button always shown when diagram renders
+- Show only fullscreen button in normal view (cleaner UI, no clutter)
+- Full pan/zoom controls (pan arrows, zoom +/- , reset) appear only in fullscreen
+- Add scroll-wheel zoom in fullscreen mode
+- Add click-and-drag to pan in fullscreen mode
+- Disable transform transition during drag for responsive feel
+- Enter key toggles fullscreen when diagram is focused

--- a/packages/flame/docs/components/mermaid.mdx
+++ b/packages/flame/docs/components/mermaid.mdx
@@ -126,9 +126,7 @@ Every rendered diagram gets a GFM-style control cluster in the bottom-right corn
 - **Reset** — restore the original position and scale
 - **Full screen** — open the diagram in a lightbox overlay; close it with the same button or <kbd>Escape</kbd>
 
-The diagram container is keyboard accessible: focus it with <kbd>Tab</kbd>, then pan with the arrow keys, zoom with <kbd>+</kbd> / <kbd>-</kbd>, and reset with <kbd>0</kbd>.
-
-Set `panZoom={false}` on the prop-based syntax to disable the controls.
+The diagram container is keyboard accessible: focus it with <kbd>Tab</kbd>, then press <kbd>Enter</kbd> to open the fullscreen view. Inside fullscreen, pan with arrow keys, zoom with <kbd>+</kbd> / <kbd>-</kbd>, and reset with <kbd>0</kbd>.
 
 ## Props
 
@@ -139,7 +137,7 @@ When using the prop-based syntax (`<Mermaid chart="...">`) instead of fenced cod
 | `chart`     | string  | —       | Mermaid diagram definition (required)           |
 | `id`        | string  | —       | Custom DOM id (auto-generated if omitted)       |
 | `className` | string  | —       | Additional CSS class on the container element   |
-| `panZoom`   | boolean | `true`  | Show pan/zoom controls once the diagram renders |
+
 
 ## Output Markdown
 
@@ -165,7 +163,7 @@ Escape hatch — prop syntax (for programmatic use):
 ## Notes
 
 - Diagrams are rendered **client-side**. During SSR, a `<pre class="mermaid">` placeholder is rendered instead.
-- **Pan, zoom, and fullscreen**: Button-driven controls (GFM-style) appear once a diagram renders, including a fullscreen lightbox toggle; mouse drag and scroll-wheel zoom are intentionally not intercepted.
+- **Pan, zoom, and fullscreen**: A fullscreen button appears after the diagram renders. Click or press Enter to open the fullscreen lightbox. Inside fullscreen, use pan/zoom buttons, arrow keys, scroll-wheel zoom, or click-and-drag to explore the diagram. Press Escape to exit.
 - **Theme synchronization**: The component automatically detects dark/light theme changes and re-renders diagrams.
 - **Lazy loading**: Off-screen diagrams are only rendered when scrolled into view (200px margin).
 - **Error fallback**: If a diagram has invalid Mermaid syntax, the raw code is shown with an error message.

--- a/packages/mdx-content/src/__test__/MermaidMdx.test.tsx
+++ b/packages/mdx-content/src/__test__/MermaidMdx.test.tsx
@@ -262,9 +262,16 @@ describe("MermaidMdx", () => {
   });
 
   describe("pan/zoom controls", () => {
-    async function renderWithControls() {
+    async function renderAndEnterFullscreen() {
       mockParse.mockResolvedValueOnce(undefined);
       const result = render(<MermaidMdx chart="graph TD; A-->B;" />);
+      await vi.waitFor(() => {
+        expect(
+          result.container.querySelector('button[aria-label="Enter full screen"]')
+        ).not.toBeNull();
+      });
+      // Enter fullscreen to show all pan/zoom controls
+      fireEvent.click(result.container.querySelector('button[aria-label="Enter full screen"]')!);
       await vi.waitFor(() => {
         expect(
           result.container.querySelector('[aria-label="Pan and zoom controls"]')
@@ -273,9 +280,30 @@ describe("MermaidMdx", () => {
       return result;
     }
 
-    it("shows all controls after the diagram renders", async () => {
-      const { container } = await renderWithControls();
+    it("shows only fullscreen button after render, full controls in fullscreen", async () => {
+      mockParse.mockResolvedValueOnce(undefined);
+      const { container } = render(<MermaidMdx chart="graph TD; A-->B;" />);
+
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('button[aria-label="Enter full screen"]')
+        ).not.toBeNull();
+      });
+
+      // Outside fullscreen: only the fullscreen button, no pan/zoom grid
+      expect(container.querySelector('[aria-label="Pan and zoom controls"]')).toBeNull();
+      expect(container.querySelector('button[aria-label="Pan up"]')).toBeNull();
+
+      // Enter fullscreen — all controls appear
+      fireEvent.click(container.querySelector('button[aria-label="Enter full screen"]')!);
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('[aria-label="Pan and zoom controls"]')
+        ).not.toBeNull();
+      });
+
       const labels = [
+        "Exit full screen",
         "Pan up",
         "Pan down",
         "Pan left",
@@ -283,24 +311,14 @@ describe("MermaidMdx", () => {
         "Zoom in",
         "Zoom out",
         "Reset view",
-        "Enter full screen",
       ];
       for (const label of labels) {
         expect(container.querySelector(`button[aria-label="${label}"]`)).not.toBeNull();
       }
     });
 
-    it("does not show controls when panZoom is false", async () => {
-      mockParse.mockResolvedValueOnce(undefined);
-      const { container } = render(<MermaidMdx chart="graph TD; A-->B;" panZoom={false} />);
-      await vi.waitFor(() => {
-        expect(mockRun).toHaveBeenCalled();
-      });
-      expect(container.querySelector('[aria-label="Pan and zoom controls"]')).toBeNull();
-    });
-
     it("zoom, pan, and reset buttons update the transform", async () => {
-      const { container } = await renderWithControls();
+      const { container } = await renderAndEnterFullscreen();
       const layer = container.querySelector("pre.mermaid")?.parentElement as HTMLElement;
 
       fireEvent.click(container.querySelector('button[aria-label="Zoom in"]')!);
@@ -314,7 +332,7 @@ describe("MermaidMdx", () => {
     });
 
     it("clamps zoom at the maximum scale", async () => {
-      const { container } = await renderWithControls();
+      const { container } = await renderAndEnterFullscreen();
       const layer = container.querySelector("pre.mermaid")?.parentElement as HTMLElement;
       const zoomIn = container.querySelector('button[aria-label="Zoom in"]')!;
 
@@ -322,8 +340,8 @@ describe("MermaidMdx", () => {
       expect(layer.style.transform).toBe("translate(0px, 0px) scale(4)");
     });
 
-    it("pans with arrow keys on the focused container", async () => {
-      const { container } = await renderWithControls();
+    it("pans with arrow keys in fullscreen mode", async () => {
+      const { container } = await renderAndEnterFullscreen();
       const viewport = container.querySelector('[tabindex="0"]') as HTMLElement;
       const layer = container.querySelector("pre.mermaid")?.parentElement as HTMLElement;
 
@@ -337,8 +355,8 @@ describe("MermaidMdx", () => {
       expect(layer.style.transform).toBe("translate(0px, 0px) scale(1)");
     });
 
-    it("ignores key presses with modifier keys (browser shortcuts)", async () => {
-      const { container } = await renderWithControls();
+    it("ignores key presses with modifier keys in fullscreen", async () => {
+      const { container } = await renderAndEnterFullscreen();
       const viewport = container.querySelector('[tabindex="0"]') as HTMLElement;
       const layer = container.querySelector("pre.mermaid")?.parentElement as HTMLElement;
 
@@ -348,19 +366,78 @@ describe("MermaidMdx", () => {
       expect(layer.style.transform).toBe("translate(0px, 0px) scale(1)");
     });
 
-    it("toggles the fullscreen lightbox via button and Escape", async () => {
-      const { container } = await renderWithControls();
+    it("zooms with mouse wheel in fullscreen mode", async () => {
+      const { container } = await renderAndEnterFullscreen();
+      const viewport = container.querySelector('[tabindex="0"]') as HTMLElement;
+      const layer = container.querySelector("pre.mermaid")?.parentElement as HTMLElement;
+
+      // Scroll up (negative delta) — zoom in
+      fireEvent.wheel(viewport, { deltaY: -100 });
+      expect(layer.style.transform).toBe("translate(0px, 0px) scale(1.2)");
+
+      // Scroll down (positive delta) — zoom out
+      fireEvent.wheel(viewport, { deltaY: 100 });
+      expect(layer.style.transform).toBe("translate(0px, 0px) scale(1)");
+    });
+
+    it("clamps zoom at minimum scale when scrolling out", async () => {
+      const { container } = await renderAndEnterFullscreen();
+      const viewport = container.querySelector('[tabindex="0"]') as HTMLElement;
+      const layer = container.querySelector("pre.mermaid")?.parentElement as HTMLElement;
+
+      for (let i = 0; i < 20; i++) fireEvent.wheel(viewport, { deltaY: 100 });
+      expect(layer.style.transform).toBe("translate(0px, 0px) scale(0.4)");
+    });
+
+    it("pans with mouse drag in fullscreen mode", async () => {
+      const { container } = await renderAndEnterFullscreen();
+      const viewport = container.querySelector('[tabindex="0"]') as HTMLElement;
+      const layer = container.querySelector("pre.mermaid")?.parentElement as HTMLElement;
+
+      // mousedown at (100, 100) then drag to (150, 120) = delta (+50, +20)
+      fireEvent.mouseDown(viewport, { clientX: 100, clientY: 100 });
+      fireEvent.mouseMove(viewport, { clientX: 150, clientY: 120 });
+      expect(layer.style.transform).toBe("translate(50px, 20px) scale(1)");
+
+      // Continue dragging to (180, 130) = additional delta (+30, +10)
+      fireEvent.mouseMove(viewport, { clientX: 180, clientY: 130 });
+      expect(layer.style.transform).toBe("translate(80px, 30px) scale(1)");
+
+      // mouseUp stops dragging; subsequent mousemove does nothing
+      fireEvent.mouseUp(viewport);
+      fireEvent.mouseMove(viewport, { clientX: 200, clientY: 150 });
+      expect(layer.style.transform).toBe("translate(80px, 30px) scale(1)");
+    });
+
+    it("toggles fullscreen via button, Enter key, and Escape", async () => {
+      mockParse.mockResolvedValueOnce(undefined);
+      const { container } = render(<MermaidMdx chart="graph TD; A-->B;" />);
+
+      await vi.waitFor(() => {
+        expect(
+          container.querySelector('button[aria-label="Enter full screen"]')
+        ).not.toBeNull();
+      });
+
       const viewport = container.querySelector('[tabindex="0"]') as HTMLElement;
 
+      // Enter via button click
       fireEvent.click(container.querySelector('button[aria-label="Enter full screen"]')!);
       expect(viewport.style.position).toBe("fixed");
       expect(document.body.style.overflow).toBe("hidden");
       expect(container.querySelector('button[aria-label="Exit full screen"]')).not.toBeNull();
+      expect(container.querySelector('[aria-label="Pan and zoom controls"]')).not.toBeNull();
 
+      // Exit via Escape
       fireEvent.keyDown(viewport, { key: "Escape" });
       expect(viewport.style.position).toBe("relative");
       expect(document.body.style.overflow).toBe("");
       expect(container.querySelector('button[aria-label="Enter full screen"]')).not.toBeNull();
+      expect(container.querySelector('[aria-label="Pan and zoom controls"]')).toBeNull();
+
+      // Enter via keyboard (Enter key) in non-fullscreen
+      fireEvent.keyDown(viewport, { key: "Enter" });
+      expect(viewport.style.position).toBe("fixed");
     });
   });
 });

--- a/packages/mdx-content/src/components/MermaidMdx.tsx
+++ b/packages/mdx-content/src/components/MermaidMdx.tsx
@@ -21,8 +21,6 @@ interface MermaidMdxProps {
   id?: string;
   /** Additional CSS class on container */
   className?: string;
-  /** Show GFM-style pan/zoom controls once the diagram renders (default true) */
-  panZoom?: boolean;
 }
 
 function getTheme(): "dark" | "default" {
@@ -87,7 +85,7 @@ function ControlButton({
   );
 }
 
-export function MermaidMdx({ chart, id, className, panZoom = true }: MermaidMdxProps) {
+export function MermaidMdx({ chart, id, className }: MermaidMdxProps) {
   const generatedId = useId();
   const domId = id ?? `mermaid-${generatedId.replace(/[:.]/g, "-")}`;
   const ref = useRef<HTMLPreElement>(null);
@@ -97,6 +95,8 @@ export function MermaidMdx({ chart, id, className, panZoom = true }: MermaidMdxP
   const [rendered, setRendered] = useState(false);
   const [view, setView] = useState({ x: 0, y: 0, scale: 1 });
   const [fullscreen, setFullscreen] = useState(false);
+  const [isPanning, setIsPanning] = useState(false);
+  const dragRef = useRef({ dragging: false, lastX: 0, lastY: 0 });
 
   // Keep chartRef in sync so theme-change re-render (T-005) can restore text
   chartRef.current = chart;
@@ -228,11 +228,22 @@ export function MermaidMdx({ chart, id, className, panZoom = true }: MermaidMdxP
   const zoom = (factor: number) => setView((v) => ({ ...v, scale: clampScale(v.scale * factor) }));
   const resetView = () => setView({ x: 0, y: 0, scale: 1 });
 
-  const controlsActive = panZoom && rendered;
+  const controlsActive = rendered && fullscreen;
+  const showFullscreenBtn = rendered;
 
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-    // Leave browser shortcuts (Ctrl/Cmd+0, Ctrl/Cmd+-, Alt+arrows, ...) alone
-    if (!controlsActive || e.ctrlKey || e.metaKey || e.altKey) return;
+    if (!showFullscreenBtn || e.ctrlKey || e.metaKey || e.altKey) return;
+
+    if (!controlsActive) {
+      // Non-fullscreen: Enter toggles fullscreen
+      if (e.key === "Enter") {
+        e.preventDefault();
+        setFullscreen(true);
+      }
+      return;
+    }
+
+    // Fullscreen mode: pan/zoom shortcuts
     const actions: Record<string, () => void> = {
       ArrowUp: () => pan(0, -PAN_STEP),
       ArrowDown: () => pan(0, PAN_STEP),
@@ -242,7 +253,7 @@ export function MermaidMdx({ chart, id, className, panZoom = true }: MermaidMdxP
       "=": () => zoom(ZOOM_STEP),
       "-": () => zoom(1 / ZOOM_STEP),
       "0": resetView,
-      ...(fullscreen ? { Escape: () => setFullscreen(false) } : {}),
+      Escape: () => setFullscreen(false),
     };
     const action = actions[e.key];
     if (!action) return;
@@ -287,14 +298,21 @@ export function MermaidMdx({ chart, id, className, panZoom = true }: MermaidMdxP
   return (
     <div
       className="max-w-full"
-      tabIndex={controlsActive ? 0 : undefined}
-      role={controlsActive ? "group" : undefined}
+      tabIndex={showFullscreenBtn ? 0 : undefined}
+      role={showFullscreenBtn ? "group" : undefined}
       aria-label={
-        controlsActive
-          ? "Mermaid diagram. Use arrow keys to pan, + and - to zoom, 0 to reset."
+        showFullscreenBtn
+          ? fullscreen
+            ? "Mermaid diagram. Use arrow keys to pan, + and - to zoom, 0 to reset."
+            : "Mermaid diagram. Press Enter to open fullscreen view."
           : undefined
       }
       onKeyDown={handleKeyDown}
+      onWheel={controlsActive ? (e) => zoom(e.deltaY > 0 ? 1 / ZOOM_STEP : ZOOM_STEP) : undefined}
+      onMouseDown={controlsActive ? (e) => { dragRef.current = { dragging: true, lastX: e.clientX, lastY: e.clientY }; setIsPanning(true); } : undefined}
+      onMouseMove={controlsActive ? (e) => { const d = dragRef.current; if (!d.dragging) return; pan(e.clientX - d.lastX, e.clientY - d.lastY); dragRef.current.lastX = e.clientX; dragRef.current.lastY = e.clientY; } : undefined}
+      onMouseUp={controlsActive ? () => { dragRef.current.dragging = false; setIsPanning(false); } : undefined}
+      onMouseLeave={controlsActive ? () => { dragRef.current.dragging = false; setIsPanning(false); } : undefined}
       style={{
         ...(fullscreen
           ? {
@@ -307,7 +325,7 @@ export function MermaidMdx({ chart, id, className, panZoom = true }: MermaidMdxP
               justifyContent: "center",
             }
           : { position: "relative" }),
-        ...(controlsActive ? { overflow: "hidden" } : { overflowX: "auto" }),
+        ...(controlsActive ? { overflow: "hidden" } : { overflow: "auto" }),
       }}
     >
       <div
@@ -316,7 +334,7 @@ export function MermaidMdx({ chart, id, className, panZoom = true }: MermaidMdxP
             ? {
                 transform: `translate(${view.x}px, ${view.y}px) scale(${view.scale})`,
                 transformOrigin: "center center",
-                transition: "transform 150ms ease",
+                transition: isPanning ? "none" : "transform 150ms ease",
               }
             : undefined
         }
@@ -331,71 +349,71 @@ export function MermaidMdx({ chart, id, className, panZoom = true }: MermaidMdxP
         </pre>
       </div>
 
-      {controlsActive ? (
-        <div
-          role="group"
-          aria-label="Pan and zoom controls"
-          style={{
-            position: "absolute",
-            bottom: 8,
-            right: 8,
-            display: "grid",
-            gridTemplateColumns: "repeat(3, 28px)",
-            gap: 4,
-          }}
-        >
-          <ControlButton
-            label={fullscreen ? "Exit full screen" : "Enter full screen"}
-            onClick={() => setFullscreen((f) => !f)}
-            cell={{ col: 1, row: 1 }}
+      {showFullscreenBtn ? (
+        controlsActive ? (
+          <div
+            role="group"
+            aria-label="Pan and zoom controls"
+            style={{
+              position: "absolute",
+              bottom: 8,
+              right: 8,
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 28px)",
+              gap: 4,
+            }}
           >
-            {fullscreen ? (
+            <ControlButton label="Exit full screen" onClick={() => setFullscreen(false)} cell={{ col: 1, row: 1 }}>
               <path d="M8 3v3a2 2 0 0 1-2 2H3M21 8h-3a2 2 0 0 1-2-2V3M3 16h3a2 2 0 0 1 2 2v3M16 21v-3a2 2 0 0 1 2-2h3" />
-            ) : (
+            </ControlButton>
+            <ControlButton label="Pan up" onClick={() => pan(0, -PAN_STEP)} cell={{ col: 2, row: 1 }}>
+              <path d="m18 15-6-6-6 6" />
+            </ControlButton>
+            <ControlButton label="Zoom in" onClick={() => zoom(ZOOM_STEP)} cell={{ col: 3, row: 1 }}>
+              <circle cx="11" cy="11" r="7" />
+              <path d="m21 21-4-4M8 11h6M11 8v6" />
+            </ControlButton>
+            <ControlButton
+              label="Pan left"
+              onClick={() => pan(-PAN_STEP, 0)}
+              cell={{ col: 1, row: 2 }}
+            >
+              <path d="m15 18-6-6 6-6" />
+            </ControlButton>
+            <ControlButton label="Reset view" onClick={resetView} cell={{ col: 2, row: 2 }}>
+              <path d="M3 12a9 9 0 1 0 2.6-6.3L3 8" />
+              <path d="M3 3v5h5" />
+            </ControlButton>
+            <ControlButton
+              label="Pan right"
+              onClick={() => pan(PAN_STEP, 0)}
+              cell={{ col: 3, row: 2 }}
+            >
+              <path d="m9 18 6-6-6-6" />
+            </ControlButton>
+            <ControlButton
+              label="Pan down"
+              onClick={() => pan(0, PAN_STEP)}
+              cell={{ col: 2, row: 3 }}
+            >
+              <path d="m6 9 6 6 6-6" />
+            </ControlButton>
+            <ControlButton
+              label="Zoom out"
+              onClick={() => zoom(1 / ZOOM_STEP)}
+              cell={{ col: 3, row: 3 }}
+            >
+              <circle cx="11" cy="11" r="7" />
+              <path d="m21 21-4-4M8 11h6" />
+            </ControlButton>
+          </div>
+        ) : (
+          <div style={{ position: "absolute", bottom: 8, right: 8 }}>
+            <ControlButton label="Enter full screen" onClick={() => setFullscreen(true)} cell={{ col: 1, row: 1 }}>
               <path d="M8 3H5a2 2 0 0 0-2 2v3M21 8V5a2 2 0 0 0-2-2h-3M3 16v3a2 2 0 0 0 2 2h3M16 21h3a2 2 0 0 0 2-2v-3" />
-            )}
-          </ControlButton>
-          <ControlButton label="Pan up" onClick={() => pan(0, -PAN_STEP)} cell={{ col: 2, row: 1 }}>
-            <path d="m18 15-6-6-6 6" />
-          </ControlButton>
-          <ControlButton label="Zoom in" onClick={() => zoom(ZOOM_STEP)} cell={{ col: 3, row: 1 }}>
-            <circle cx="11" cy="11" r="7" />
-            <path d="m21 21-4-4M8 11h6M11 8v6" />
-          </ControlButton>
-          <ControlButton
-            label="Pan left"
-            onClick={() => pan(-PAN_STEP, 0)}
-            cell={{ col: 1, row: 2 }}
-          >
-            <path d="m15 18-6-6 6-6" />
-          </ControlButton>
-          <ControlButton label="Reset view" onClick={resetView} cell={{ col: 2, row: 2 }}>
-            <path d="M3 12a9 9 0 1 0 2.6-6.3L3 8" />
-            <path d="M3 3v5h5" />
-          </ControlButton>
-          <ControlButton
-            label="Pan right"
-            onClick={() => pan(PAN_STEP, 0)}
-            cell={{ col: 3, row: 2 }}
-          >
-            <path d="m9 18 6-6-6-6" />
-          </ControlButton>
-          <ControlButton
-            label="Pan down"
-            onClick={() => pan(0, PAN_STEP)}
-            cell={{ col: 2, row: 3 }}
-          >
-            <path d="m6 9 6 6 6-6" />
-          </ControlButton>
-          <ControlButton
-            label="Zoom out"
-            onClick={() => zoom(1 / ZOOM_STEP)}
-            cell={{ col: 3, row: 3 }}
-          >
-            <circle cx="11" cy="11" r="7" />
-            <path d="m21 21-4-4M8 11h6" />
-          </ControlButton>
-        </div>
+            </ControlButton>
+          </div>
+        )
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Summary

Improve Mermaid diagram viewing UX by showing controls contextually instead of always visible. Remove the `panZoom` prop — the fullscreen button now always appears when a diagram renders.

## Changes

- **@docubook/mdx-content** — MermaidMdx component: remove `panZoom` prop, implement contextual controls
- **@docubook/flame** — docs: update mermaid component documentation

## New UX Flow

| State | What the user sees |
|---|---|
| **Normal (diagram fits viewport)** | Only a fullscreen button at bottom-right. No pan/zoom clutter. |
| **Overflow (diagram exceeds viewport)** | Native scroll handles panning. Fullscreen button still visible. |
| **Fullscreen mode** | All pan/zoom controls appear + wheel zoom + drag pan. |

## Comparison: Figma / Excalidraw vs Ours

| Dimension | Figma | Excalidraw | Ours |
|---|---|---|---|
| Canvas model | Infinite canvas | Infinite canvas | Embedded in page |
| Zoom | Scroll wheel (always active) | Scroll wheel (always active) | Scroll wheel (fullscreen only) |
| Pan | Space+drag / middle mouse | Click-drag (grab cursor) | Click-drag (fullscreen only) |
| Controls | None (gesture-only) | Minimal toolbar | Button grid (fullscreen only) |
| Fullscreen | N/A (canvas is fullscreen) | N/A | Toggle via button / Enter / Escape |
| Keyboard navigation | None | None | Arrow keys + +/- + 0 |

### Rationale Behind Each Decision

**1. Infinite canvas is not suitable for documentation.** Figma and Excalidraw are design tools — their canvas is full-page by nature and users work inside it. Mermaid diagrams are embedded content inside a documentation page. Adding gesture-based zoom/pan in embedded mode would conflict with page scrolling and text selection.

**2. Button controls for discoverability.** Figma/Excalidraw users are designers accustomed to gesture-based navigation. Documentation users are a general audience — buttons are more discoverable and require no prior knowledge.

**3. Fullscreen as a bridge.** Embedded diagrams need room for exploration. Fullscreen provides that room without sacrificing page layout. Most diagrams fit the viewport, but some are complex. Fullscreen offers an escape hatch without compromising the reading experience.

**4. Wheel zoom + drag pan limited to fullscreen.** In embedded mode: wheel zoom conflicts with page scroll, drag pan conflicts with text selection. In fullscreen (overlay with overflow hidden), these conflicts do not exist.

**5. Only the fullscreen button in normal mode.** Diagrams that fit the viewport do not need pan/zoom controls — adding them would create visual clutter. The fullscreen button still serves as a signal: "there is more to explore here."

**6. Keyboard shortcuts in fullscreen.** Accessibility and power users. Arrow keys for precise panning, +/- for zoom steps, 0 to reset.

## Backward Compatibility

- `panZoom` prop **removed**. The fullscreen button is always shown.
- Users who relied on `panZoom={false}` can no longer opt out.
- All other props (`chart`, `id`, `className`) remain unchanged.