### PR TITLE
fix: bump overrides for undici to ^7.29.0 and fast-uri to ^4.1.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ overrides:
   "@types/react-dom": 19.2.3
   "@sentry/bun": ">=10.0.0"
   read-yaml-file: ^2.1.0
-  undici: ^7.28.0
-  fast-uri: ^4.1.1
+  undici: ^7.29.0
+  fast-uri: ^4.1.2
   dompurify: ^3.4.12
 
 importers:
@@ -4451,10 +4451,10 @@ packages:
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
       }
 
-  fast-uri@4.1.1:
+  fast-uri@4.1.2:
     resolution:
       {
-        integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==,
+        integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==,
       }
 
   fastq@1.20.1:
@@ -7532,10 +7532,10 @@ packages:
         integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==,
       }
 
-  undici@7.28.0:
+  undici@7.29.0:
     resolution:
       {
-        integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==,
+        integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==,
       }
     engines: { node: ">=20.18.1" }
 
@@ -9659,7 +9659,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10682,7 +10682,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -11241,7 +11241,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -12861,7 +12861,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,8 +11,8 @@ overrides:
   "@types/react-dom": "19.2.3"
   "@sentry/bun": ">=10.0.0"
   "read-yaml-file": "^2.1.0"
-  undici: "^7.28.0"
-  fast-uri: "^4.1.1"
+  undici: "^7.29.0"
+  fast-uri: "^4.1.2"
   dompurify: "^3.4.12"
 allowBuilds:
   "@parcel/watcher": true


### PR DESCRIPTION
## What

Bumps pnpm overrides in `pnpm-workspace.yaml` to patched versions:

- `undici` ^7.28.0 → ^7.29.0
- `fast-uri` ^4.1.1 → ^4.1.2

## Why

Closes **6 open Dependabot alerts** (all dev-scope transitive deps in `pnpm-lock.yaml`):

| # | Sev | Advisory |
|---|-----|----------|
| 36 | med | undici CRLF injection via blob-like body |
| 35 | med | undici cookie attribute injection |
| 34 | med | undici info disclosure via Cache-Control |
| 33 | high | undici info disclosure + parse-time crash |
| 32 | med | undici response desync via retry interceptor |
| 31 | high | fast-uri host confusion via backslash authority |

## Validation

- `pnpm install` re-resolved lockfile to `undici@7.29.0` / `fast-uri@4.1.2`
- Lockfile diff is limited to the version bumps (+20/-20)
- Dependabot auto-closes alerts after its next scan

## Note

Override is intentionally conservative (^7.29.0 vs latest 8.x) to avoid a breaking undici major bump — upstream allows bumping to 8.x later if desired.