### PR TITLE
docs(flame): concise meta title and v2 markdown-first description

### DIFF
--- a/packages/flame/docu.json
+++ b/packages/flame/docu.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://cdn.jsdelivr.net/npm/@docubook/flame/docu.schema.json",
   "meta": {
-    "title": "Flame - Docs Framework",
-    "description": "A blazing-fast React + MDX framework powered by Bun, built for modern documentation experiences.",
+    "title": "DocuBook Flame",
+    "description": "A markdown-first documentation framework. Write with directives, compile to flat static HTML — no runtime, no server, no lock-in. Runs on Bun, Node.js, or Deno.",
     "baseURL": "https://docubook.pro",
     "favicon": "/docs/assets/images/favicon.ico",
     "ogImage": "/docs/assets/images/og.png"


### PR DESCRIPTION
## Summary

Small docs-site config update in `packages/flame/docu.json`.

- **`meta.title`** — trimmed to the brand only: `DocuBook Flame` (super-DRY; the description carries the story)
- **`meta.description`** — reworded to the v2 markdown-first positioning: directives-based authoring, flat static HTML output, no runtime/server/lock-in, Bun/Node/Deno

The old copy described the v1 "React + MDX framework" era and no longer matches the v2 direction ("Compile markdown. Deploy anything.").

## Testing

JSON validated. Docs-only change — no code touched.