### PR TITLE
feat(flame): sidebar accordion, unified tooltip bubble, single-tag release — v2.0.0-alpha.2

### DIFF
--- a/.changeset/breaking-v2.md
+++ b/.changeset/breaking-v2.md
@@ -121,3 +121,41 @@ Real changes shipped since `2.0.0-alpha.0`:
   no internal package list
 - ARCHITECTURE.md: rewritten to the v2 codebase (package map, eval-free
   hydration, corrected CSP/cache values)
+
+## 2.0.0-alpha.1 → 2.0.0-alpha.2
+
+Real changes shipped since `2.0.0-alpha.1`:
+
+### `@docubook/markdown` — fix
+
+- **fix:** tooltip renders as one unified chat bubble — the tail notch now
+  paints on top of the body with a 2px overlap, so the body border flows
+  continuously into the notch outline (previously two separate borders at
+  the junction); open-path tail (no stroke on the attachment edge), concave
+  sides read as a proper bubble notch
+
+### `@docubook/flame` — fix/feat
+
+- **feat:** sidebar groups are exclusive accordions — level 2+ groups
+  (e.g. Search) default closed, expand on header click, opening one closes
+  the other; the group containing the active page auto-expands; chevron uses
+  the tree convention (right when closed, down when open)
+- **fix:** nested `noLink` groups are styled as links, not section headers
+  (no `font-medium`/bold below the top section)
+- **fix:** scaffold CSS in the npm install layout — ui-react's Tailwind
+  `@source` now lives inside the package's own `styles.css` (imported via
+  `@docubook/ui-react/styles.css`) instead of a monorepo-relative path that
+  resolves nowhere when the package is installed from a registry
+
+### `@docubook/ui-react` — feat
+
+- **feat:** ships a `styles.css` (`@source "./src"`) so consumers scan the
+  component classes from any install layout
+
+### Release (repo)
+
+- **fix:** releases create a single `v<flame version>` tag instead of one tag
+  per package — the changesets action publishes all linked packages but
+  skips per-package GitHub releases; CI removes the per-package tags and
+  creates one `v2.x` tag + release
+- **chore:** all packages bumped `2.0.0-alpha.1` → `2.0.0-alpha.2`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,36 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm publish-packages
           version: pnpm version-packages
           commit: "chore: version packages"
           title: "chore: version packages"
+          # Single product release — flame is the only output; the step below
+          # creates the one `v<flame version>` tag and GitHub release, so
+          # disable the per-package releases the action would otherwise create.
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: "0"
+
+      - name: Create single GitHub Release (v<flame version>)
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          VERSION=$(node -p "require('./packages/flame/package.json').version")
+          TAG="v${VERSION}"
+          # The product ships as ONE tag (flame version). `changeset publish`
+          # tags every published package (@docubook/*@<version>) — remove them
+          # from local + origin and keep only the v<version> tag.
+          for T in $(git tag -l "@docubook/*@${VERSION}"); do
+            git tag -d "$T"
+            git push origin --delete "$T" 2>/dev/null || true
+          done
+          git tag -f "$TAG"
+          git push origin "$TAG"
+          gh release create "$TAG" --title "$TAG" --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/core",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Shared MDX compile pipeline and markdown utilities for DocuBook",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/flame/.docu/components/Menu.tsx
+++ b/packages/flame/.docu/components/Menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import Sublink from "./Sublink";
+import Sublink, { GroupAccordionProvider } from "./Sublink";
 import SidebarGroupHeader from "./SidebarGroupHeader";
 import type { DocuRoute } from "../node/types";
 import { cn } from "../node/utils";
@@ -76,28 +76,32 @@ export default function Menu({ onNavigate, className = "", pathname, routes = []
     // No context routes defined — fall back to flat list of all routes
     if (contextRoutes.length === 0) {
       return (
-        <nav {...navProps}>
-          <ul className={sharedUlClasses}>
-            {menuRoutes.map((route) => renderBorderItem(route, "", route.href))}
-          </ul>
-        </nav>
+        <GroupAccordionProvider>
+          <nav {...navProps}>
+            <ul className={sharedUlClasses}>
+              {menuRoutes.map((route) => renderBorderItem(route, "", route.href))}
+            </ul>
+          </nav>
+        </GroupAccordionProvider>
       );
     }
 
     return (
-      <nav {...navProps}>
-        {contextRoutes.map((route, i) => (
-          <div key={route.href} className={i > 0 ? "mt-6 lg:mt-8" : ""}>
-            <SidebarGroupHeader
-              icon={route.context?.icon}
-              title={route.context?.title || route.title}
-            />
-            <ul className={sharedUlClasses}>
-              {route.items?.map((item) => renderBorderItem(item, route.href, item.href))}
-            </ul>
-          </div>
-        ))}
-      </nav>
+      <GroupAccordionProvider>
+        <nav {...navProps}>
+          {contextRoutes.map((route, i) => (
+            <div key={route.href} className={i > 0 ? "mt-6 lg:mt-8" : ""}>
+              <SidebarGroupHeader
+                icon={route.context?.icon}
+                title={route.context?.title || route.title}
+              />
+              <ul className={sharedUlClasses}>
+                {route.items?.map((item) => renderBorderItem(item, route.href, item.href))}
+              </ul>
+            </div>
+          ))}
+        </nav>
+      </GroupAccordionProvider>
     );
   }
 
@@ -119,18 +123,20 @@ export default function Menu({ onNavigate, className = "", pathname, routes = []
   if (!contextRoute) return null;
 
   return (
-    <nav {...navProps}>
-      <ul className="flex flex-col gap-0.5 py-4">
-        <li key={contextRoute.title}>
-          <Sublink
-            {...contextRoute}
-            href={contextRoute.href}
-            level={0}
-            onNavigate={onNavigate}
-            parentHref="/docs"
-          />
-        </li>
-      </ul>
-    </nav>
+    <GroupAccordionProvider>
+      <nav {...navProps}>
+        <ul className="flex flex-col gap-0.5 py-4">
+          <li key={contextRoute.title}>
+            <Sublink
+              {...contextRoute}
+              href={contextRoute.href}
+              level={0}
+              onNavigate={onNavigate}
+              parentHref="/docs"
+            />
+          </li>
+        </ul>
+      </nav>
+    </GroupAccordionProvider>
   );
 }

--- a/packages/flame/.docu/components/Sublink.tsx
+++ b/packages/flame/.docu/components/Sublink.tsx
@@ -1,11 +1,42 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from "react";
 import { ChevronDown } from "lucide-react";
 import Anchor from "./Anchor";
 import type { DocuRoute } from "../node/types";
 import { cn, docsHtmlHref } from "../node/utils";
 import { config as docuConfig } from "../node/client-routes";
+
+/** Exclusive accordion for level >= 2 sidebar groups — opening one group
+ * closes the previously open one. All level >= 2 groups default to closed
+ * and expand only when the header is clicked. `open` is used to auto-expand
+ * the group containing the active page. */
+export const GroupAccordionContext = createContext<{
+  openId: string | null;
+  open: (id: string) => void;
+  toggle: (id: string) => void;
+}>({ openId: null, open: () => {}, toggle: () => {} });
+
+export function GroupAccordionProvider({ children }: { children: ReactNode }) {
+  const [openId, setOpenId] = useState<string | null>(null);
+  // Exclusive: expanding B closes A — only one group stays open at a time;
+  // clicking the open group again collapses it.
+  const open = useCallback((id: string) => setOpenId(id), []);
+  const toggle = useCallback((id: string) => setOpenId((prev) => (prev === id ? null : id)), []);
+  return (
+    <GroupAccordionContext.Provider value={{ openId, open, toggle }}>
+      {children}
+    </GroupAccordionContext.Provider>
+  );
+}
 
 interface SublinkProps extends DocuRoute {
   level: number;
@@ -28,11 +59,38 @@ export default function Sublink({
   const currentPathname =
     pathnameProp || (typeof window !== "undefined" ? window.location.pathname : "/docs");
 
+  // Groups with children are exclusive accordions (default closed, expand on
+  // click). In separator mode every nav item renders at level 0 (sections are
+  // SidebarGroupHeader, not Sublinks), so depth can't tell them apart — the
+  // mode does. In dropdown mode the top section is level 0 (stays open) and
+  // everything deeper is an accordion.
+  const isSeparator = docuConfig.sidebar?.context === "separator";
+  const { openId, open, toggle } = useContext(GroupAccordionContext);
+  const isAccordionGroup = Boolean(items) && (isSeparator || level >= 1);
+  // Routes-tree level: separator mode renders every item at level 0 (sections
+  // are SidebarGroupHeader), dropdown starts the context section at level 0.
+  const treeLevel = level + (isSeparator ? 2 : 1);
+
   const [isOpen, setIsOpen] = useState(() => {
-    if (level === 0) return true;
-    if (!items) return false;
-    return currentPathname.startsWith(fullHref) && currentPathname !== fullHref;
+    if (isAccordionGroup) return false; // default closed — context controls it
+    if (level === 0) return true; // top-level section stays open
+    return false; // leaves
   });
+
+  const effectiveOpen = isAccordionGroup ? openId === fullHref : isOpen;
+  const handleToggle = () => {
+    if (isAccordionGroup) toggle(fullHref);
+    else setIsOpen((o) => !o);
+  };
+
+  // Auto-expand the accordion group that contains the active page — on mount
+  // and whenever the current path changes. `open` is stable (useCallback), so
+  // this only fires on real path changes; a manual collapse by the user is
+  // respected until the path changes again.
+  const isInsideActive = currentPathname.startsWith(fullHref) && currentPathname !== fullHref;
+  useEffect(() => {
+    if (isAccordionGroup && isInsideActive) open(fullHref);
+  }, [isAccordionGroup, isInsideActive, fullHref, open]);
 
   // Shared padding based on nesting level
   const levelPadding = cn(level === 1 && "pl-4", level === 2 && "pl-8", level >= 3 && "pl-12");
@@ -113,12 +171,15 @@ export default function Sublink({
       {/* Section header */}
       <button
         type="button"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={handleToggle}
         className={cn(
           "flex w-full cursor-pointer items-center justify-between py-1 text-left text-sm transition-colors",
-          noLink
+          // Only the top-level section label (routes-tree level 1) is bold.
+          // Deeper groups (e.g. Search at level 2) are children that happen to
+          // have items — style them like links, no header weight.
+          noLink && treeLevel === 1
             ? "text-base-content font-semibold"
-            : "text-base-content/80 hover:text-base-content font-medium"
+            : "text-foreground hover:text-foreground/80"
         )}
       >
         {noLink ? (
@@ -137,13 +198,15 @@ export default function Sublink({
         <ChevronDown
           className={cn(
             "text-base-content/40 h-4 w-4 shrink-0 transition-transform duration-200",
-            isOpen && "rotate-180"
+            // Tree convention: closed = chevron pointing right (expandable),
+            // open = pointing down — a 90° turn instead of the 180° flip.
+            effectiveOpen ? "rotate-0" : "-rotate-90"
           )}
         />
       </button>
 
       {/* Children */}
-      {isOpen && (
+      {effectiveOpen && (
         <div className="flex flex-col py-1">
           {items.map((item) => (
             <Sublink

--- a/packages/flame/.docu/styles/globals.css
+++ b/packages/flame/.docu/styles/globals.css
@@ -9,7 +9,7 @@
 @plugin "@tailwindcss/typography";
 @source "../../.docu/components";
 @source "../../.docu/pages";
-@source "../../../ui-react/src";
+@import "@docubook/ui-react/styles.css";
 
 /* daisyUI breadcrumbs underline every li child on hover (including plain
    spans) — crumbs are not links, so strip the underline (and pointer cursor)

--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/flame",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "A blazing-fast React + MDX framework powered by Bun, built for modern documentation experiences.",
   "type": "module",
   "bin": {

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/markdown",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Portable MDX components and framework adapters for DocuBook",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/markdown/src/components/TooltipMdx.tsx
+++ b/packages/markdown/src/components/TooltipMdx.tsx
@@ -69,12 +69,14 @@ export function TooltipMdx({ text, tip }: TooltipMdxProps) {
 
     // Tail: horizontal center tracks the trigger; vertical edge depends on
     // the flip — bubble below trigger → tail at the TOP (tip up), bubble
-    // above → tail at the BOTTOM (tip down). TAIL_PAD of overlap lets the
-    // body cover the closing edge.
+    // above → tail at the BOTTOM (tip down). Overlap the body border by
+    // TAIL_PAD + 1 (2px) so the tail fill fully covers the body's border at
+    // the junction — with only 1px the border's outer half still shows
+    // through as a separate line across the tail base.
     const tailCenter = trigger.left + trigger.width / 2 - left;
     setTailStyle({
       left: Math.min(Math.max(tailCenter - TAIL_SIZE / 2, 2), bubble.width - TAIL_SIZE - 2),
-      top: flip ? -TAIL_PROTRUSION + TAIL_PAD : bubble.height - TAIL_PAD,
+      top: flip ? -TAIL_PROTRUSION + TAIL_PAD + 1 : bubble.height - TAIL_PAD - 1,
     });
   }, [open]);
 
@@ -84,23 +86,26 @@ export function TooltipMdx({ text, tip }: TooltipMdxProps) {
   const borderColor = "hsl(var(--border-color, 210 20% 85%))";
 
   // Quadratic Bézier tail path (tip points down when the bubble sits above
-  // the trigger, up otherwise). Each control point sits at the midpoint of
-  // the shoulder→tip segment, pulled slightly OUTWARD (concave side) — the
-  // taper stays almost straight, so the notch narrows sharply from wide to
-  // point instead of bulging.
+  // the trigger, up otherwise). OPEN path (no Z close) so the attachment edge
+  // has no stroke: it sits under the bubble body, and only the curved sides
+  // + tip carry the border stroke — otherwise the closing edge's 1px line
+  // shows through at the bubble's border and collides with its rounding.
+  // Control points sit at the midpoint of the shoulder→tip segment, pulled
+  // INWARD (concave) so the notch reads as a chat-bubble tail, pinched
+  // sharply from wide shoulders to a point.
   const tipY = TAIL_PROTRUSION + TAIL_PAD;
   const shoulderY = TAIL_PAD;
   const tipX = TAIL_TIP_X + TAIL_PAD;
   const midY = (shoulderY + tipY) / 2;
-  const curveOut = 1.4; // outward pull (px) — smaller = straighter, sharper
+  const curveIn = 2.5; // inward pull (px) — concave notch
   const leftMid = (TAIL_PAD + tipX) / 2;
   const rightMid = (tipX + TAIL_SIZE + TAIL_PAD) / 2;
-  const curveLeft = leftMid - curveOut;
-  const curveRight = rightMid + curveOut;
+  const curveLeft = leftMid + curveIn;
+  const curveRight = rightMid - curveIn;
   const rightX = TAIL_SIZE + TAIL_PAD;
   const tailPath = below
-    ? `M ${TAIL_PAD} ${tipY} Q ${curveLeft} ${midY} ${tipX} ${shoulderY} Q ${curveRight} ${midY} ${rightX} ${tipY} Z`
-    : `M ${TAIL_PAD} ${shoulderY} Q ${curveLeft} ${midY} ${tipX} ${tipY} Q ${curveRight} ${midY} ${rightX} ${shoulderY} Z`;
+    ? `M ${TAIL_PAD} ${tipY} Q ${curveLeft} ${midY} ${tipX} ${shoulderY} Q ${curveRight} ${midY} ${rightX} ${tipY}`
+    : `M ${TAIL_PAD} ${shoulderY} Q ${curveLeft} ${midY} ${tipX} ${tipY} Q ${curveRight} ${midY} ${rightX} ${shoulderY}`;
 
   return (
     <span
@@ -136,17 +141,10 @@ export function TooltipMdx({ text, tip }: TooltipMdxProps) {
           role="tooltip"
           style={{ position: "fixed", ...bubbleStyle, zIndex: 9999 }}
         >
-          {/* Notched tail — rendered behind the bubble body so the body covers
-              the closing edge; only the curved notch and its stroke show. */}
-          <svg
-            aria-hidden="true"
-            width={TAIL_SIZE}
-            height={TAIL_PROTRUSION}
-            viewBox={`0 0 ${TAIL_W} ${TAIL_H}`}
-            style={{ position: "absolute", ...tailStyle, display: "block" }}
-          >
-            <path d={tailPath} fill={bubbleColor} stroke={borderColor} strokeWidth={1} />
-          </svg>
+          {/* Body first, tail painted ON TOP — the tail's fill (same colour as
+              the body) covers the body's border where they meet, so the bubble
+              outline flows continuously into the notch instead of showing two
+              separate borders. */}
           <span
             style={{
               position: "relative",
@@ -166,6 +164,15 @@ export function TooltipMdx({ text, tip }: TooltipMdxProps) {
           >
             {content}
           </span>
+          <svg
+            aria-hidden="true"
+            width={TAIL_SIZE}
+            height={TAIL_PROTRUSION}
+            viewBox={`0 0 ${TAIL_W} ${TAIL_H}`}
+            style={{ position: "absolute", ...tailStyle, display: "block" }}
+          >
+            <path d={tailPath} fill={bubbleColor} stroke={borderColor} strokeWidth={1} />
+          </svg>
         </span>
       ) : null}
     </span>

--- a/packages/themes-colors/package.json
+++ b/packages/themes-colors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/themes-colors",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Theme color presets and color utilities for DocuBook \u2014 hex-to-HSL, CSS variable generation, and 3 built-in themes (Default/Blue, Fresh Lime, Coffee).",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/ui-react",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "React + DaisyUI component library for documentation sites",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -136,11 +136,13 @@
         "types": "./dist/pagination.d.cts",
         "default": "./dist/pagination.cjs"
       }
-    }
+    },
+    "./styles.css": "./styles.css"
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "styles.css"
   ],
   "sideEffects": false,
   "scripts": {

--- a/packages/ui-react/styles.css
+++ b/packages/ui-react/styles.css
@@ -1,0 +1,4 @@
+/* Tailwind source root for ui-react components — @source is resolved relative
+   to this file, so consumers can import this stylesheet from any install
+   layout and the component classes are still scanned. */
+@source "./src";


### PR DESCRIPTION
## Summary

**v2.0.0-alpha.2** — sidebar navigation accordion, unified tooltip bubble, scaffold CSS fix, and a single-tag release process. 12 files, +215/−72.

## Sidebar accordion (flame)

- **Exclusive accordion for groups** — level 2+ groups (e.g. Search) default closed, expand on header click, opening one closes the other (single `openId` in a shared context)
- **Auto-expand active group** — the group containing the current page opens itself (mount + path change); manual collapse by the user is respected until the path changes
- **Groups styled as links, not headers** — nested `noLink` groups (level 2+) use link styling (`text-foreground`, normal weight); only the top section label stays `font-semibold`; works in both separator and dropdown sidebar modes (routes-tree level derived per mode)
- **Chevron tree convention** — 90° rotation: points right when closed (expandable), down when open (was a 180° flip)

## Tooltip unified bubble (markdown)

- Tail notch now paints **on top** of the body with a **2px overlap** — the body border flows continuously into the notch outline instead of two separate borders at the junction (verified via pixel analysis)
- Open-path tail (no stroke on the attachment edge), concave sides read as a proper chat-bubble notch

## Scaffold CSS fix (flame + ui-react)

- `@source "../../../ui-react/src"` in globals.css was **monorepo-path-dependent** — it resolves nowhere when flame is installed from a registry (`node_modules/@docubook/flame` → `../../../ui-react` doesn't exist), so scaffolded projects lost all ui-react classes (pagination styling broke)
- Fix: ui-react ships its own `styles.css` with `@source "./src"` (resolved relative to that file, layout-independent); flame's globals.css imports `@docubook/ui-react/styles.css`
- Proven in the real npm install layout: classes present, pagination renders correctly

## Release process (repo)

- **Single tag `v<flame version>`** instead of one tag per package — `createGithubReleases: false` on the changesets action; CI removes the per-package tags (`@docubook/*@<version>`) created by `changeset publish` and creates one `v2.x` tag + GitHub release
- All packages bumped `2.0.0-alpha.1` → `2.0.0-alpha.2`; changeset gains the alpha.1 → alpha.2 real-changes section

## Testing

- Playwright: accordion default-closed + expand + exclusivity + active auto-open, tooltip junction pixel analysis (unified border), scaffold CSS in npm layout
- flame 441/441, markdown 99/99, typecheck clean
