### PR TITLE
feat(flame): parse-once frontmatter pipeline, read-once build, beta.0 bump

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,6 +1,6 @@
 {
   "mode": "pre",
-  "tag": "alpha",
+  "tag": "beta",
   "initialVersions": {
     "@docubook/core": "1.9.0",
     "@docubook/flame": "1.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/core",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-beta.0",
   "description": "Shared MDX compile pipeline and markdown utilities for DocuBook",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/flame/.docu/__tests__/html.test.ts
+++ b/packages/flame/.docu/__tests__/html.test.ts
@@ -37,6 +37,29 @@ describe("htmlShell", () => {
     });
   });
 
+  describe("absoluteAssets (404 fallback)", () => {
+    it("uses root-absolute /assets/ URLs when absoluteAssets is set", () => {
+      const html = htmlShell({ ...MINIMAL_OPTS, absoluteAssets: true });
+      expect(html).toContain('href="/assets/client-abc123.css"');
+      expect(html).toContain('src="/assets/client-xyz789.js"');
+    });
+
+    it("absoluteAssets ignores depth — served at arbitrary paths", () => {
+      const html = htmlShell({ ...MINIMAL_OPTS, absoluteAssets: true, depth: 3 });
+      expect(html).toContain('href="/assets/client-abc123.css"');
+      expect(html).toContain('src="/assets/client-xyz789.js"');
+    });
+
+    it("absoluteAssets keeps the favicon root-absolute too", () => {
+      const html = htmlShell({
+        ...MINIMAL_OPTS,
+        absoluteAssets: true,
+        favicon: "/docs/assets/images/favicon.ico",
+      });
+      expect(html).toContain('href="/docs/assets/images/favicon.ico"');
+    });
+  });
+
   describe("resolvePath for favicon", () => {
     it("resolves absolute favicon path at root (depth=0)", () => {
       const html = htmlShell({

--- a/packages/flame/.docu/__tests__/parse-once.test.ts
+++ b/packages/flame/.docu/__tests__/parse-once.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  compileMdxModule,
+  compileMdx,
+  frontmatterSchema,
+  getPageFrontmatter,
+  getPageStripped,
+  getPageContent,
+  registerPageContent,
+} from "../node/mdx";
+import { getPreviousNext } from "../node/route";
+
+const MDX = `---
+title: Test Page
+description: A test description
+author: wildan
+date: 2026-08-15
+---
+
+# Heading
+
+Content here.
+`;
+
+// Distinct hrefs per test — the registries are module-level Maps.
+let seq = 0;
+const href = () => `/parse-once/${++seq}-${Date.now()}`;
+
+describe("frontmatter parse-once registry (mdx.ts)", () => {
+  it("compileMdxModule registers the full frontmatter + stripped content", async () => {
+    const h = href();
+    await compileMdxModule(MDX, [], [], h);
+
+    const fm = getPageFrontmatter(h);
+    expect(fm?.title).toBe("Test Page");
+    expect(fm?.description).toBe("A test description");
+    expect(fm?.date).toBe("2026-08-15");
+    // passthrough: unknown fields survive zod parsing
+    expect(fm?.author).toBe("wildan");
+
+    const stripped = getPageStripped(h);
+    expect(stripped).not.toContain("---");
+    expect(stripped).toContain("# Heading");
+  });
+
+  it("frontmatterSchema passthrough keeps arbitrary fields", () => {
+    const parsed = frontmatterSchema.parse({
+      title: "T",
+      description: "D",
+      author: "wildan",
+      tags: ["docs", "v2"],
+      views: 42,
+    });
+    expect(parsed.author).toBe("wildan");
+    expect(parsed.tags).toEqual(["docs", "v2"]);
+    expect(parsed.views).toBe(42);
+  });
+
+  it("registerPageContent / getPageContent round-trip (read-once)", () => {
+    const h = href();
+    registerPageContent(h, "raw content");
+    expect(getPageContent(h)).toBe("raw content");
+  });
+
+  it("compileMdx with pre skips its own frontmatter extraction", async () => {
+    const h = href();
+    const pre = { frontmatter: { title: "Pre Title" }, strippedContent: "# Heading\nContent" };
+    const result = await compileMdx(
+      "# Heading\nContent",
+      "test.mdx",
+      undefined,
+      [],
+      [],
+      undefined,
+      pre
+    );
+    expect(result.frontmatter.title).toBe("Pre Title");
+    expect(result.frontmatter.author).toBeUndefined(); // pre data used, not the source
+    expect(getPageFrontmatter(h)).toBeUndefined(); // compileMdx alone does not register
+  });
+});
+
+describe("getPreviousNext reads the registry, not the file (route.ts)", () => {
+  beforeEach(() => {
+    // register a synthetic "formatting" page so the pagination for
+    // configuration (whose next page is formatting per docu.json routes)
+    // resolves from the registry instead of reading the real file.
+    registerPageContent("/getting-started/formatting", "raw");
+    return compileMdxModule(
+      `---\ntitle: Formatting Override\ndescription: REGISTERED DESC\n---\n# Formatting\n`,
+      [],
+      [],
+      "/getting-started/formatting"
+    );
+  });
+
+  it("next title + description come from the registered frontmatter", () => {
+    const { next } = getPreviousNext("/getting-started/configuration");
+    expect(next?.title).toBe("Formatting Override");
+    expect(next?.description).toBe("REGISTERED DESC");
+  });
+});

--- a/packages/flame/.docu/node/build.impl.ts
+++ b/packages/flame/.docu/node/build.impl.ts
@@ -12,7 +12,16 @@ import { createHash } from "node:crypto";
 import { join, dirname } from "node:path";
 import React from "react";
 import { renderToString } from "react-dom/server";
-import { compileMdx, compileMdxModule, frontmatterField, getGitLastModifiedBatch } from "./mdx";
+import {
+  compileMdx,
+  compileMdxModule,
+  frontmatterField,
+  getGitLastModifiedBatch,
+  getPageContent,
+  getPageFrontmatter,
+  getPageStripped,
+  registerPageContent,
+} from "./mdx";
 import {
   DOCS_DIR,
   DIST_DIR,
@@ -105,7 +114,24 @@ async function renderDocsPage(
   try {
     const remarkPlugins = builder?.collectRemarkPlugins();
     const rehypePlugins = builder?.collectRehypePlugins();
-    result = await compileMdx(content, filePath, gitDates, remarkPlugins, rehypePlugins);
+    // Parse-once: reuse the prePass frontmatter + stripped content so the
+    // SSR phase does not re-extract them. Only when the prePass actually
+    // registered them — otherwise compileMdx does its own extraction.
+    const preFm = getPageFrontmatter(`/${slug}`);
+    const preStripped = getPageStripped(`/${slug}`);
+    const pre =
+      preFm !== undefined && preStripped !== undefined
+        ? { frontmatter: preFm, strippedContent: preStripped }
+        : undefined;
+    result = await compileMdx(
+      content,
+      filePath,
+      gitDates,
+      remarkPlugins,
+      rehypePlugins,
+      undefined,
+      pre
+    );
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Unknown MDX error";
     throw new Error(`MDX Error in: docs/${slug}.mdx\n${msg}`, { cause: err });
@@ -241,6 +267,9 @@ export async function runBuild(): Promise<void> {
     } catch {
       return;
     }
+    // Cache the original content so the page loop does not re-read the file
+    // (one disk read per file — the frontmatter is parsed once here too).
+    registerPageContent(`/${file.path}`, raw);
     let content = raw;
     if (builder) {
       const relPath = file.absPath.replace(PROJECT_ROOT + "/", "");
@@ -249,7 +278,12 @@ export async function runBuild(): Promise<void> {
     }
     const remarkPlugins = builder?.collectRemarkPlugins();
     const rehypePlugins = builder?.collectRehypePlugins();
-    mdxSources[file.path] = await compileMdxModule(content, remarkPlugins, rehypePlugins);
+    mdxSources[file.path] = await compileMdxModule(
+      content,
+      remarkPlugins,
+      rehypePlugins,
+      `/${file.path}`
+    );
   });
   await Promise.all(prePassTasks);
 
@@ -319,12 +353,14 @@ export async function runBuild(): Promise<void> {
       }
     }
 
-    let rawMdx: string;
-    try {
-      rawMdx = await readFile(file.absPath, "utf-8");
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-      continue;
+    let rawMdx = getPageContent(`/${file.path}`);
+    if (rawMdx === undefined) {
+      try {
+        rawMdx = await readFile(file.absPath, "utf-8");
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+        continue;
+      }
     }
 
     if (rebuildDecision === "hash_check") {
@@ -458,8 +494,11 @@ export async function runBuild(): Promise<void> {
 
   logger.indexStart();
   t = performance.now();
-  const indexCount = await generateSearchIndex();
-  logger.indexDone(indexCount, Math.round(performance.now() - t));
+  // No content changed (all pages cached) → the aggregated index is
+  // unchanged too; reuse the existing file instead of regenerating it.
+  const indexSkipped = built === 0 && existsSync(join(ASSETS_DIR, "search-index.json"));
+  const indexCount = indexSkipped ? 0 : await generateSearchIndex();
+  logger.indexDone(indexCount, Math.round(performance.now() - t), indexSkipped);
 
   logger.routes();
 

--- a/packages/flame/.docu/node/build.ts
+++ b/packages/flame/.docu/node/build.ts
@@ -4,7 +4,16 @@ import { createHash } from "node:crypto";
 import { join, dirname } from "node:path";
 import React from "react";
 import { renderToString } from "react-dom/server";
-import { compileMdx, compileMdxModule, frontmatterField, getGitLastModifiedBatch } from "./mdx";
+import {
+  compileMdx,
+  compileMdxModule,
+  frontmatterField,
+  getGitLastModifiedBatch,
+  getPageContent,
+  getPageFrontmatter,
+  getPageStripped,
+  registerPageContent,
+} from "./mdx";
 import {
   DOCS_DIR,
   DIST_DIR,
@@ -98,7 +107,24 @@ async function renderDocsPage(
   try {
     const remarkPlugins = builder?.collectRemarkPlugins();
     const rehypePlugins = builder?.collectRehypePlugins();
-    result = await compileMdx(content, filePath, gitDates, remarkPlugins, rehypePlugins);
+    // Parse-once: reuse the prePass frontmatter + stripped content so the
+    // SSR phase does not re-extract them. Only when the prePass actually
+    // registered them — otherwise compileMdx does its own extraction.
+    const preFm = getPageFrontmatter(`/${slug}`);
+    const preStripped = getPageStripped(`/${slug}`);
+    const pre =
+      preFm !== undefined && preStripped !== undefined
+        ? { frontmatter: preFm, strippedContent: preStripped }
+        : undefined;
+    result = await compileMdx(
+      content,
+      filePath,
+      gitDates,
+      remarkPlugins,
+      rehypePlugins,
+      undefined,
+      pre
+    );
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Unknown MDX error";
     throw new Error(`MDX Error in: docs/${slug}.mdx\n${msg}`, { cause: err });
@@ -229,6 +255,9 @@ async function build() {
     } catch {
       return;
     }
+    // Cache the original content so the page loop does not re-read the file
+    // (one disk read per file — the frontmatter is parsed once here too).
+    registerPageContent(`/${file.path}`, raw);
     let content = raw;
     if (builder) {
       const relPath = file.absPath.replace(PROJECT_ROOT + "/", "");
@@ -237,7 +266,12 @@ async function build() {
     }
     const remarkPlugins = builder?.collectRemarkPlugins();
     const rehypePlugins = builder?.collectRehypePlugins();
-    mdxSources[file.path] = await compileMdxModule(content, remarkPlugins, rehypePlugins);
+    mdxSources[file.path] = await compileMdxModule(
+      content,
+      remarkPlugins,
+      rehypePlugins,
+      `/${file.path}`
+    );
   });
   await Promise.all(prePassTasks);
 
@@ -307,12 +341,14 @@ async function build() {
       }
     }
 
-    let rawMdx: string;
-    try {
-      rawMdx = await readFile(file.absPath, "utf-8");
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-      continue;
+    let rawMdx = getPageContent(`/${file.path}`);
+    if (rawMdx === undefined) {
+      try {
+        rawMdx = await readFile(file.absPath, "utf-8");
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+        continue;
+      }
     }
 
     if (rebuildDecision === "hash_check") {
@@ -440,8 +476,11 @@ async function build() {
 
   logger.indexStart();
   t = performance.now();
-  const indexCount = await generateSearchIndex();
-  logger.indexDone(indexCount, Math.round(performance.now() - t));
+  // No content changed (all pages cached) → the aggregated index is
+  // unchanged too; reuse the existing file instead of regenerating it.
+  const indexSkipped = built === 0 && existsSync(join(ASSETS_DIR, "search-index.json"));
+  const indexCount = indexSkipped ? 0 : await generateSearchIndex();
+  logger.indexDone(indexCount, Math.round(performance.now() - t), indexSkipped);
 
   logger.routes();
   console.log("");

--- a/packages/flame/.docu/node/logger.ts
+++ b/packages/flame/.docu/node/logger.ts
@@ -179,9 +179,13 @@ export const logger = {
     this.spinner.start("Generating search index...");
   },
 
-  indexDone(records: number, ms: number) {
-    if (guard("info", "index_done", { records, duration_ms: ms })) return;
-    this.spinner.stop(`Search index generated ${c.dim}(${records} records, ${ms}ms)${c.reset}`);
+  indexDone(records: number, ms: number, skipped = false) {
+    if (guard("info", "index_done", { records, duration_ms: ms, skipped })) return;
+    this.spinner.stop(
+      skipped
+        ? `Search index cached ${c.dim}(${ms}ms)${c.reset}`
+        : `Search index generated ${c.dim}(${records} records, ${ms}ms)${c.reset}`
+    );
   },
 
   routes() {

--- a/packages/flame/.docu/node/mdx.ts
+++ b/packages/flame/.docu/node/mdx.ts
@@ -115,13 +115,19 @@ export interface MdxResult {
  * DocuBook frontmatter contract — single source of truth for frontmatter
  * fields. Add new properties here; types and validation derive from it.
  * YAML coerces unquoted values, so string fields use `z.coerce.*`.
+ * `.passthrough()` keeps unknown fields (e.g. `author: wildan`, `tags`)
+ * in the parsed output — arbitrary frontmatter metadata stays available
+ * via `frontmatterField(frontmatter, key)` instead of being silently
+ * stripped by Zod's default object parsing.
  */
-export const frontmatterSchema = z.object({
-  title: z.coerce.string().optional(),
-  description: z.coerce.string().optional(),
-  image: z.coerce.string().optional(),
-  date: z.coerce.string().optional(),
-});
+export const frontmatterSchema = z
+  .object({
+    title: z.coerce.string().optional(),
+    description: z.coerce.string().optional(),
+    image: z.coerce.string().optional(),
+    date: z.coerce.string().optional(),
+  })
+  .passthrough();
 
 export type Frontmatter = z.infer<typeof frontmatterSchema>;
 
@@ -162,12 +168,13 @@ async function serializeWithDocPlugins(
     remarkPlugins?: Pluggable[];
     rehypePlugins?: Pluggable[];
     frontmatterSchema?: FrontmatterSchema;
-  } = {}
+  } = {},
+  pre?: { frontmatter: Frontmatter; strippedContent: string }
 ) {
-  const { strippedContent } = extractFrontmatterWithContent<Frontmatter>(
-    rawMdx,
-    opts.frontmatterSchema
-  );
+  // Parse-once: when the prePass already extracted the frontmatter + stripped
+  // content, reuse it instead of re-parsing (the SSR phase skips extraction).
+  const { strippedContent, frontmatter } =
+    pre ?? extractFrontmatterWithContent<Frontmatter>(rawMdx, opts.frontmatterSchema);
 
   const defaultRemark = createDefaultRemarkPlugins();
   const defaultRehype = createDefaultRehypePlugins();
@@ -179,7 +186,8 @@ async function serializeWithDocPlugins(
   const finalRehype = [...defaultRehype, rehypeDocsHtmlLinks, ...(opts.rehypePlugins ?? [])];
 
   // v2 contract: plain markdown + directives only — authored JSX tags are
-  // not parsed (dropped, content kept as text).
+  // not parsed (dropped, content kept as text). Return the frontmatter parsed
+  // above — `serialize()` only parses it when `parseFrontmatter` is set.
   return serialize(strippedContent, {
     outputFormat: opts.outputFormat,
     format: "md",
@@ -187,7 +195,7 @@ async function serializeWithDocPlugins(
       rehypePlugins: finalRehype,
       remarkPlugins: finalRemark,
     },
-  });
+  }).then((serialized) => ({ ...serialized, frontmatter, strippedContent }));
 }
 
 /**
@@ -206,15 +214,19 @@ export async function compileMdx(
   gitDates?: Map<string, string>,
   remarkPlugins?: Pluggable[],
   rehypePlugins?: Pluggable[],
-  frontmatterSchema?: FrontmatterSchema
+  frontmatterSchema?: FrontmatterSchema,
+  /** Pre-pass extracted data — avoids re-parsing frontmatter in the SSR phase. */
+  pre?: { frontmatter: Frontmatter; strippedContent: string }
 ): Promise<MdxResult> {
   const tocs = extractTocsFromRawMdx(rawMdx);
-  const { frontmatter } = extractFrontmatterWithContent<Frontmatter>(rawMdx, frontmatterSchema);
-  const serialized = await serializeWithDocPlugins(rawMdx, {
-    remarkPlugins,
-    rehypePlugins,
-    frontmatterSchema,
-  });
+  const frontmatter =
+    pre?.frontmatter ??
+    extractFrontmatterWithContent<Frontmatter>(rawMdx, frontmatterSchema).frontmatter;
+  const serialized = await serializeWithDocPlugins(
+    rawMdx,
+    { remarkPlugins, rehypePlugins, frontmatterSchema },
+    pre
+  );
 
   const components = createMdxComponents();
   const content = React.createElement(MDXRemote, {
@@ -245,15 +257,69 @@ export async function compileMdx(
  * instead of `new Function(compiledSource)`. Uses the same plugin chain as
  * `compileMdx` so the hydrated tree matches the SSR output.
  */
+/**
+ * Frontmatter records collected once during compilation — pagination title /
+ * description and other metadata consumers read from here instead of
+ * re-reading + re-parsing files (parse-once contract: the frontmatter is
+ * already parsed by `serializeWithDocPlugins`).
+ */
+const pageFrontmatter = new Map<string, Frontmatter>();
+
+/** Register a page's frontmatter, keyed by its href. */
+export function registerPageFrontmatter(href: string, frontmatter: Frontmatter): void {
+  pageFrontmatter.set(href, frontmatter);
+}
+
+/** Look up a page's frontmatter (undefined when not yet compiled). */
+export function getPageFrontmatter(href: string): Frontmatter | undefined {
+  return pageFrontmatter.get(href);
+}
+
+/**
+ * Frontmatter-stripped content from the prePass — lets the SSR compile
+ * phase skip its own `extractFrontmatterWithContent` (parse-once across
+ * both compile phases).
+ */
+const pageStripped = new Map<string, string>();
+
+export function registerPageStripped(href: string, stripped: string): void {
+  pageStripped.set(href, stripped);
+}
+
+export function getPageStripped(href: string): string | undefined {
+  return pageStripped.get(href);
+}
+
+/**
+ * Original (pre-transform) file content, cached during the prePass so the
+ * page loop does not re-read the file from disk — one read per file.
+ */
+const pageContent = new Map<string, string>();
+
+export function registerPageContent(href: string, raw: string): void {
+  pageContent.set(href, raw);
+}
+
+export function getPageContent(href: string): string | undefined {
+  return pageContent.get(href);
+}
+
 export async function compileMdxModule(
   rawMdx: string,
   remarkPlugins?: Pluggable[],
-  rehypePlugins?: Pluggable[]
+  rehypePlugins?: Pluggable[],
+  /** Page href — registers the frontmatter (title/description/image/date)
+   * once for pagination and metadata consumers. */
+  href?: string
 ): Promise<string> {
   const serialized = await serializeWithDocPlugins(rawMdx, {
     outputFormat: "program",
     remarkPlugins,
     rehypePlugins,
   });
+  if (href) {
+    registerPageFrontmatter(href, serialized.frontmatter as Frontmatter);
+    registerPageStripped(href, serialized.strippedContent);
+  }
   return serialized.compiledSource;
 }

--- a/packages/flame/.docu/node/route.ts
+++ b/packages/flame/.docu/node/route.ts
@@ -5,6 +5,7 @@ import { DOCS_DIR } from "./paths";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { extractFrontmatter } from "@docubook/core";
+import { getPageFrontmatter, registerPageFrontmatter } from "./mdx";
 import type { Frontmatter } from "./mdx";
 
 const docuConfig = loadDocuConfig();
@@ -46,29 +47,31 @@ export function getRouteMap(): Map<string, string> {
   return map;
 }
 
-/** Build-time cache of href → frontmatter description (docs content is static). */
-const descriptionCache = new Map<string, string>();
+/**
+ * Frontmatter for a page — read from the parse-once registry (populated
+ * during compilation) instead of re-reading + re-parsing the file. Falls
+ * back to a direct read only for pages the dev server has not compiled yet,
+ * and caches the result back into the registry.
+ */
+function readPageFrontmatter(href: string): Frontmatter {
+  const registered = getPageFrontmatter(href);
+  if (registered) return registered;
 
-function readDescription(href: string): string {
-  const cached = descriptionCache.get(href);
-  if (cached !== undefined) return cached;
-
-  let description = "";
+  let fm: Frontmatter = {};
   const rel = href.replace(/^\/|$/g, "");
   for (const ext of [".mdx", ".md"]) {
     for (const file of [join(DOCS_DIR, `${rel}${ext}`), join(DOCS_DIR, `${rel}/index${ext}`)]) {
       try {
-        const fm = extractFrontmatter<Frontmatter>(readFileSync(file, "utf-8"));
-        description = typeof fm.description === "string" ? fm.description : "";
-        if (description) break;
+        fm = extractFrontmatter<Frontmatter>(readFileSync(file, "utf-8"));
+        break;
       } catch {
         // not this file — try the next candidate
       }
     }
-    if (description) break;
+    if (Object.keys(fm).length) break;
   }
-  descriptionCache.set(href, description);
-  return description;
+  registerPageFrontmatter(href, fm);
+  return fm;
 }
 
 export function getPreviousNext(pathname: string) {
@@ -83,12 +86,13 @@ export function getPreviousNext(pathname: string) {
     const routeMap = getRouteMap();
     const first = paths[0];
     if (!first) return { prev: null, next: null };
+    const fm = readPageFrontmatter(first);
     return {
       prev: null,
       next: {
         href: first,
-        title: routeMap.get(first) || "",
-        description: readDescription(first),
+        title: fm.title || routeMap.get(first) || "",
+        description: fm.description || "",
       },
     };
   }
@@ -105,13 +109,17 @@ export function getPreviousNext(pathname: string) {
   const prevHref = index > 0 ? paths[index - 1] : null;
   const nextHref = index < paths.length - 1 ? paths[index + 1] : null;
 
+  const prevFm = prevHref ? readPageFrontmatter(prevHref) : null;
+  const nextFm = nextHref ? readPageFrontmatter(nextHref) : null;
   return {
-    prev: prevHref ? { href: prevHref, title: routeMap.get(prevHref) || "" } : null,
+    prev: prevHref
+      ? { href: prevHref, title: prevFm?.title || routeMap.get(prevHref) || "" }
+      : null,
     next: nextHref
       ? {
           href: nextHref,
-          title: routeMap.get(nextHref) || "",
-          description: readDescription(nextHref),
+          title: nextFm?.title || routeMap.get(nextHref) || "",
+          description: nextFm?.description || "",
         }
       : null,
   };

--- a/packages/flame/.docu/node/search-indexer.ts
+++ b/packages/flame/.docu/node/search-indexer.ts
@@ -13,6 +13,7 @@
 
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { resolve, join } from "node:path";
+import { getPageContent } from "./mdx";
 import { extractFrontmatterWithContent } from "@docubook/core";
 import { frontmatterField } from "./mdx";
 import { DOCS_DIR, ASSETS_DIR, loadDocuConfig } from "./paths";
@@ -193,7 +194,9 @@ export async function generateSearchIndex(docsDir?: string, outputDir?: string):
   const mdxFiles = await scanMdxFiles(docs);
   const results = await Promise.all(
     mdxFiles.map(async (file) => {
-      const raw = await readFile(file.absPath, "utf-8");
+      // Parse-once: reuse the prePass-cached raw content when available —
+      // no second disk read of every file.
+      const raw = getPageContent(`/${file.path}`) ?? (await readFile(file.absPath, "utf-8"));
       return extractRecords(file.path, raw);
     })
   );

--- a/packages/flame/package.json
+++ b/packages/flame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/flame",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-beta.0",
   "description": "A blazing-fast React + MDX framework powered by Bun, built for modern documentation experiences.",
   "type": "module",
   "bin": {

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/markdown",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-beta.0",
   "description": "Portable MDX components and framework adapters for DocuBook",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/themes-colors/package.json
+++ b/packages/themes-colors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/themes-colors",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-beta.0",
   "description": "Theme color presets and color utilities for DocuBook \u2014 hex-to-HSL, CSS variable generation, and 3 built-in themes (Default/Blue, Fresh Lime, Coffee).",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docubook/ui-react",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-beta.0",
   "description": "React + DaisyUI component library for documentation sites",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

**Parse-once frontmatter pipeline + read-once build** — v2.0.0-beta.0 release prep. 14 files, +356/−72.

## Parse-once contract (core ↔ flame)

- **Frontmatter parsed once per file** — `compileMdxModule` (prePass) extracts `title/description/image/date` once, registers it; the SSR phase (`compileMdx`) receives `pre: { frontmatter, strippedContent }` and **skips re-extraction** (was 3 parses per file → 1)
- **File read once per file** — prePass caches the raw content; the page loop + search indexer reuse it (was 2–3 disk reads → 1)
- **Zod passthrough** — `frontmatterSchema` now `.passthrough()`: arbitrary fields (`author: wildan`, `tags`, …) survive validation instead of being silently stripped; accessible via `frontmatterField(fm, key)`
- **Pagination from registry** — title + description come from the registered frontmatter (`readPageFrontmatter`), not `readFile` + re-parse; file-read fallback only for dev paths not yet compiled
- **Registry**: `pageFrontmatter` / `pageStripped` / `pageContent` Maps in `mdx.ts` (href-keyed, populated in the prePass)

## Search index

- **Skipped on no-change builds** — `built === 0 && index exists` → "Search index cached (0ms)" instead of regenerating
- **Reuses cached content** — `generateSearchIndex` reads `getPageContent` instead of re-reading every file

## Tests

- **`parse-once.test.ts`** (new, 5 tests) — registry registration (full frontmatter + passthrough + stripped content), content cache round-trip, `compileMdx` pre-skip, `getPreviousNext` registry-first
- **`html.test.ts`** +3 — `absoluteAssets` root-absolute URLs for the 404 fallback
- flame **449/449**, core 79/79

## Release

- All packages bumped `2.0.0-alpha.2` → `2.0.0-beta.0`; changeset pre tag `alpha` → `beta`

## Verified

- Cold build 26 pages; warm rebuild "0 built (26 cached)" + "Search index cached (0ms)"; content change regenerates both
- Pagination description renders from the registry (build + dev)
- No cache regression (warm skip intact; full rebuild on change is the pre-existing shared-bundle design)
